### PR TITLE
Remove USE_SYSTEM_DATE from examples

### DIFF
--- a/examples/usage_fetch_content/dependencies/sqlpp23/CMakeLists.txt
+++ b/examples/usage_fetch_content/dependencies/sqlpp23/CMakeLists.txt
@@ -29,6 +29,4 @@
 # set(BUILD_SQLITE3_CONNECTOR ON)
 # set(BUILD_SQLCIPHER_CONNECTOR ON)
 
-# set(USE_SYSTEM_DATE ON)
-
 FetchContent_MakeAvailable(sqlpp23)


### PR DESCRIPTION
This PR removes the USE_SYSTEM_DATE define from one of the examples, because this define is no longer supported.