### PR TITLE
Remove superfluous output to std::cerr

### DIFF
--- a/include/sqlpp23/postgresql/result.h
+++ b/include/sqlpp23/postgresql/result.h
@@ -82,8 +82,6 @@ class DLL_PUBLIC Result {
     check_index(record, field);
     auto t = int64_t{};
     const auto txt = std::string{get_pq_value(m_result, record, field)};
-    std::cerr << "txt: " << txt << ", record: " << record
-              << ", field: " << field << std::endl;
     if (txt != "") {
       t = std::stoll(txt);
     }


### PR DESCRIPTION
This PR removes a bit of debug code in `sqlpp::postgresql::Result::get_int64_value()` that writes to `std::cerr` regardless of the connector debug flag.

Given that the other `get_xxxxx_value()` functions don't write to `std::cerr`, the one in `get_int64_value()` seems like a remnant of some debug code that was left unintentionally.