### PR TITLE
Fix result iterators

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,3 +1,6 @@
+# Add tests that use query results as ranges
+Add tests that use result_t in range operations. Also check if result_t::iterator satisfies the std::input_iterator concept.
+
 # Allow use as module
 
 # Need to document: aggregates

--- a/include/sqlpp23/core/result.h
+++ b/include/sqlpp23/core/result.h
@@ -79,7 +79,7 @@ class result_t {
   class iterator {
    public:
     using iterator_category = std::input_iterator_tag;
-    using data_type = result_row_t;
+    using value_type = result_row_t;
     using pointer = const result_row_t*;
     using reference = const result_row_t&;
     using difference_type = std::ptrdiff_t;


### PR DESCRIPTION
This commit https://github.com/rbock/sqlpp23/commit/6b41e5fcb7a9814b8a6bd85a9206dec4f692759d#diff-2a99a66fbe2fb8432e9a5de3343b0757475a951fdb8bec7a2e07e4452cdd36bcL197
renamed `result_t::iterator::value_type` to `data_type` and thus broke the usage of query results as ranges because `result_t::iterator` no longer satisfies the `std::input_iterator` concept.

This PR renames the `result_t::iterator::data_type` back to `value_type` and thus fixes all my code that uses ranges :-)

I really need to add tests for the results being used as input ranges, so that is why I also updated the TODO. Right now I am a bit busy, but I will really try to find the time to add the tests in the next couple of weeks or so.