### PR TITLE
Do not include the obsolete header ciso646

### DIFF
--- a/include/sqlpp23/core/database/transaction.h
+++ b/include/sqlpp23/core/database/transaction.h
@@ -27,7 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ciso646>
 #include <stdexcept>
 #include <string>
 

--- a/include/sqlpp23/core/logic.h
+++ b/include/sqlpp23/core/logic.h
@@ -27,7 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ciso646>  // Required for some compilers to use aliases for boolean operators
 #include <type_traits>
 
 namespace sqlpp::logic {

--- a/include/sqlpp23/mysql/char_result.h
+++ b/include/sqlpp23/mysql/char_result.h
@@ -38,7 +38,6 @@
 #include <sqlpp23/mysql/char_result_row.h>
 #include <sqlpp23/mysql/detail/result_handle.h>
 #include <sqlpp23/mysql/sqlpp_mysql.h>
-#include <ciso646>
 #include <cstdlib>
 #include <iostream>
 #include <memory>

--- a/include/sqlpp23/sqlite3/prepared_statement.h
+++ b/include/sqlpp23/sqlite3/prepared_statement.h
@@ -28,7 +28,6 @@
  */
 
 #include <chrono>
-#include <ciso646>
 #include <cmath>
 #include <memory>
 #include <string>


### PR DESCRIPTION
This PR removes all includes of `ciso646`.

Currently sqlpp23 includes the obsolete header `ciso646` in several places, which causes compile warnings like this with `g++ (GCC) 15.0.1 20250329 (Red Hat 15.0.1-0)`
```
[ 78%] Building CXX object tests/postgresql/serialize/data_types/CMakeFiles/sqlpp23_postgresql_serialize_data_types_microseconds.dir/microseconds.cpp.o
In file included from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/logic.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/detail/type_set.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/type_traits.h:39,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/default_value.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/basic/column.h:31,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/basic/table.h:31,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/clause/single_table.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/core/clause/delete_from.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/postgresql/clause/delete_from.h:30,
                 from /usr/local/projects/github/sqlpp23/include/sqlpp23/postgresql/postgresql.h:31,
                 from /usr/local/projects/github/sqlpp23/tests/postgresql/serialize/data_types/microseconds.cpp:27:
/usr/include/c++/15/ciso646:46:4: warning: #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Wcpp]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
      |    ^~~~~~~
```
The purpose of this header is to define the alternative operator representations (`not`, `and`, `or`, etc.), but since these alternative representations are builtin keywords in C++, including this header does not make any difference on modern compilers. It seems that some older compilers actually required this header in order to define the alternative representations, but the modern versions of gcc, clang and msvc do not need this header.

Moreover `ciso646` has been removed from the C++20 standard, which causes the newest g++ to emit the above warning.