### PR TITLE
ddl2cpp: Mark columns that are GENERATED as having a default value

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -752,6 +752,7 @@ def createHeader():
             columnHasDefault = column.hasDefaultValue or \
                                column.hasSerialValue or \
                                column.hasAutoValue or \
+                               column.hasGeneratedValue or \
                                (autoId and sqlColumnName == "id") or \
                                columnCanBeNull
             if columnHasDefault:


### PR DESCRIPTION
I just noticed a small defect in my previous PR (https://github.com/rbock/sqlpp23/pull/18). 

The GENERATED columns were not marked as having a default value. This followup PR fixes that.
