### PR TITLE
Use deducing this in SQLPP_NAME_TAG_GUTS and SQLPP_QUOTED_NAME_TAG_GUTS

### DIFF
--- a/include/sqlpp23/core/name/create_name_tag.h
+++ b/include/sqlpp23/core/name/create_name_tag.h
@@ -36,11 +36,8 @@
   template <typename T>                                            \
   struct _member_t {                                               \
     T CPP_NAME = {};                                               \
-    T& operator()() {                                              \
-      return CPP_NAME;                                             \
-    }                                                              \
-    const T& operator()() const {                                  \
-      return CPP_NAME;                                             \
+    auto& operator()(this auto&& self) {                           \
+      return self.CPP_NAME;                                        \
     }                                                              \
   }
 
@@ -61,11 +58,8 @@
   template <typename T>                                \
   struct _member_t {                                   \
     T CPP_NAME = {};                                   \
-    T& operator()() {                                  \
-      return CPP_NAME;                                 \
-    }                                                  \
-    const T& operator()() const {                      \
-      return CPP_NAME;                                 \
+    auto& operator()(this auto&& self) {               \
+      return self.CPP_NAME;                            \
     }                                                  \
   }
 


### PR DESCRIPTION
As per the discussion in https://github.com/rbock/sqlpp23/issues/20, this PR uses deducing this to simplify the code in SQLPP_NAME_TAG_GUTS and SQLPP_QUOTED_NAME_TAG_GUTS.

The PR has been built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DDEPENDENCY_CHECK=ON
```
All tests passes successfully.