### PR TITLE
Replace std::make_optional(expr) -> std::optional{expr}

### DIFF
--- a/tests/core/constraints/basic/value.cpp
+++ b/tests/core/constraints/basic/value.cpp
@@ -58,5 +58,5 @@ int main() {
   static_assert(cannot_call_value_with<decltype(foo.id + 7)>);
   static_assert(cannot_call_value_with<decltype((foo.id + 7).as(something))>);
   static_assert(cannot_call_value_with<decltype(sqlpp::value(7))>);
-  static_assert(cannot_call_value_with<decltype(std::make_optional(s))>);
+  static_assert(cannot_call_value_with<decltype(std::optional{s})>);
 }

--- a/tests/core/constraints/operator/assign_expression.cpp
+++ b/tests/core/constraints/operator/assign_expression.cpp
@@ -116,7 +116,7 @@ int main() {
   // Non-nullable without default cannot be assigned null / default
   static_assert(
       not can_call_assign_with<decltype(bar.boolNn),
-                               decltype(std::make_optional(true))>::value,
+                               decltype(std::optional{true})>::value,
       "");
   static_assert(not can_call_assign_with<decltype(bar.boolNn),
                                          decltype(std::nullopt)>::value,
@@ -130,7 +130,7 @@ int main() {
       can_call_assign_with<decltype(foo.textNnD), decltype("cake")>::value, "");
   static_assert(
       not can_call_assign_with<decltype(foo.textNnD),
-                               decltype(std::make_optional("cake"))>::value,
+                               decltype(std::optional{"cake"})>::value,
       "");
   static_assert(not can_call_assign_with<decltype(foo.textNnD),
                                          decltype(std::nullopt)>::value,
@@ -145,7 +145,7 @@ int main() {
       not can_call_assign_with<decltype(const_col), decltype(7)>::value, "");
   static_assert(
       not can_call_assign_with<decltype(const_col),
-                               decltype(std::make_optional(7))>::value,
+                               decltype(std::optional{7})>::value,
       "");
   static_assert(not can_call_assign_with<decltype(const_col),
                                          decltype(std::nullopt)>::value,

--- a/tests/core/constraints/operator/case.cpp
+++ b/tests/core/constraints/operator/case.cpp
@@ -64,7 +64,7 @@ int main() {
   // OK
   static_assert(can_call_case_when_with<decltype(true)>);
   static_assert(
-      can_call_case_when_with<decltype(std::make_optional(true))>);
+      can_call_case_when_with<decltype(std::optional{true})>);
   static_assert(can_call_case_when_with<decltype(foo.boolN)>);
   static_assert(can_call_case_when_with<decltype(bar.boolNn)>);
   static_assert(can_call_case_when_with<decltype(bar.boolNn == true)>);

--- a/tests/core/types/aggregate_function/avg.cpp
+++ b/tests/core/types/aggregate_function/avg.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_avg(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using OptFloat = sqlpp::data_type_of_t<std::optional<float>>;
 

--- a/tests/core/types/aggregate_function/count.cpp
+++ b/tests/core/types/aggregate_function/count.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_count(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // count of non-nullable
   static_assert(

--- a/tests/core/types/aggregate_function/max.cpp
+++ b/tests/core/types/aggregate_function/max.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_max(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using OptDataType = sqlpp::data_type_of_t<std::optional<Value>>;
 

--- a/tests/core/types/aggregate_function/min.cpp
+++ b/tests/core/types/aggregate_function/min.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_min(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using OptDataType = sqlpp::data_type_of_t<std::optional<Value>>;
 

--- a/tests/core/types/aggregate_function/over.cpp
+++ b/tests/core/types/aggregate_function/over.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_aggregate_functions(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using OptDataType = sqlpp::data_type_of_t<std::optional<Value>>;
 
@@ -115,7 +115,7 @@ void test_aggregate_functions(Value v) {
 template <typename Value>
 void test_numeric_aggregate_functions(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using DataType = typename std::conditional<std::is_same<Value, bool>::value,
                                               int, Value>::type;

--- a/tests/core/types/aggregate_function/sum.cpp
+++ b/tests/core/types/aggregate_function/sum.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_sum(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using DataType = typename std::conditional<std::is_same<Value, bool>::value,
                                               int, Value>::type;

--- a/tests/core/types/basic/value.cpp
+++ b/tests/core/types/basic/value.cpp
@@ -36,7 +36,7 @@ void test_value(Value v) {
   using OptDataType = std::optional<DataType>;
 
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   static_assert(is_data_type<decltype(v_not_null), DataType>::value, "");
   static_assert(is_data_type<decltype(v_maybe_null), OptDataType>::value, "");

--- a/tests/core/types/clause/select_as.cpp
+++ b/tests/core/types/clause/select_as.cpp
@@ -46,7 +46,7 @@ SQLPP_CREATE_NAME_TAG(foo);
 template <typename Value>
 void test_select_as(Value v) {
   auto v_not_null = sqlpp::value(v).as(always);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v)).as(sometimes);
+  auto v_maybe_null = sqlpp::value(std::optional{v}).as(sometimes);
 
   using DataType = sqlpp::data_type_of_t<Value>;
   using OptDataType = sqlpp::data_type_of_t<std::optional<Value>>;

--- a/tests/core/types/dynamic.cpp
+++ b/tests/core/types/dynamic.cpp
@@ -41,9 +41,9 @@ void test_dynamic(Value v) {
   using OptDataType = std::optional<DataType>;
 
   auto v_not_null = dynamic(true, sqlpp::value(v));
-  auto v_maybe_null = dynamic(true, sqlpp::value(std::make_optional(v)));
+  auto v_maybe_null = dynamic(true, sqlpp::value(std::optional{v}));
   auto v_alias = sqlpp::value(v).as(r_not_null);
-  auto v_maybe_alias = sqlpp::value(std::make_optional(v)).as(r_maybe_null);
+  auto v_maybe_alias = sqlpp::value(std::optional{v}).as(r_maybe_null);
   auto v_not_null_alias = dynamic(true, v_alias);
   auto v_maybe_null_alias = dynamic(true, v_maybe_alias);
 

--- a/tests/core/types/function/coalesce.cpp
+++ b/tests/core/types/function/coalesce.cpp
@@ -36,7 +36,7 @@ using is_same_type = std::is_same<sqlpp::data_type_of_t<T>, V>;
 template <typename Value>
 void test_avg(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using ValueType = sqlpp::data_type_of_t<Value>;
   using OptValueType = sqlpp::data_type_of_t<std::optional<Value>>;

--- a/tests/core/types/operator/any.cpp
+++ b/tests/core/types/operator/any.cpp
@@ -39,7 +39,7 @@ void test_any(Value v) {
   // Selectable values.
   const auto v_not_null = sqlpp::value(v).as(r_not_null);
   const auto v_maybe_null =
-      sqlpp::value(std::make_optional(v)).as(r_maybe_null);
+      sqlpp::value(std::optional{v}).as(r_maybe_null);
 
   // ANY expression are not to be in most expressions and therefore have no
   // value defined.

--- a/tests/core/types/operator/arithmetic_expression.cpp
+++ b/tests/core/types/operator/arithmetic_expression.cpp
@@ -44,8 +44,8 @@ void test_plus(Left raw_l, Right raw_r, DataType) {
   auto l = sqlpp::value(raw_l);
   auto r = sqlpp::value(raw_r);
 
-  auto opt_l = sqlpp::value(std::make_optional(raw_l));
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_l = sqlpp::value(std::optional{raw_l});
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(
       is_same_type<sqlpp::data_type_of_t<decltype(l + r)>, DataType>(), "");
@@ -80,8 +80,8 @@ void test_minus(Left raw_l, Right raw_r, DataType) {
   auto l = sqlpp::value(raw_l);
   auto r = sqlpp::value(raw_r);
 
-  auto opt_l = sqlpp::value(std::make_optional(raw_l));
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_l = sqlpp::value(std::optional{raw_l});
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(
       is_same_type<sqlpp::data_type_of_t<decltype(l - r)>, DataType>(), "");
@@ -116,8 +116,8 @@ void test_multiplies(Left raw_l, Right raw_r, DataType) {
   auto l = sqlpp::value(raw_l);
   auto r = sqlpp::value(raw_r);
 
-  auto opt_l = sqlpp::value(std::make_optional(raw_l));
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_l = sqlpp::value(std::optional{raw_l});
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(
       is_same_type<sqlpp::data_type_of_t<decltype(l * r)>, DataType>(), "");
@@ -151,7 +151,7 @@ void test_negate(Right raw_r, DataType) {
 
   auto r = sqlpp::value(raw_r);
 
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(is_same_type<sqlpp::data_type_of_t<decltype(-r)>, DataType>(),
                 "");
@@ -179,8 +179,8 @@ void test_divides(Left raw_l, Right raw_r, DataType) {
   auto l = sqlpp::value(raw_l);
   auto r = sqlpp::value(raw_r);
 
-  auto opt_l = sqlpp::value(std::make_optional(raw_l));
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_l = sqlpp::value(std::optional{raw_l});
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(
       is_same_type<sqlpp::data_type_of_t<decltype(l / r)>, DataType>(), "");
@@ -215,8 +215,8 @@ void test_modulus(Left raw_l, Right raw_r, DataType) {
   auto l = sqlpp::value(raw_l);
   auto r = sqlpp::value(raw_r);
 
-  auto opt_l = sqlpp::value(std::make_optional(raw_l));
-  auto opt_r = sqlpp::value(std::make_optional(raw_r));
+  auto opt_l = sqlpp::value(std::optional{raw_l});
+  auto opt_r = sqlpp::value(std::optional{raw_r});
 
   static_assert(
       is_same_type<sqlpp::data_type_of_t<decltype(l % r)>, DataType>(), "");
@@ -250,7 +250,7 @@ void test_concatenation_expressions(Value v) {
   using OptDataType = std::optional<sqlpp::text>;
 
   auto value = sqlpp::value(v);
-  auto opt_value = sqlpp::value(std::make_optional(v));
+  auto opt_value = sqlpp::value(std::optional{v});
 
   // Concatenating non-optional values
   static_assert(is_same_type<sqlpp::data_type_of_t<decltype(value + value)>,

--- a/tests/core/types/operator/as_expression.cpp
+++ b/tests/core/types/operator/as_expression.cpp
@@ -35,10 +35,10 @@ using is_select_column_data_type =
 template <typename Value>
 void test_as_expression(Value v) {
   auto v_not_null = sqlpp::value(v).as(cheese);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v)).as(cheese);
+  auto v_maybe_null = sqlpp::value(std::optional{v}).as(cheese);
   auto v_dynamic_not_null = dynamic(true, sqlpp::value(v).as(cheese));
   auto v_dynamic_maybe_null =
-      dynamic(true, sqlpp::value(std::make_optional(v)).as(cheese));
+      dynamic(true, sqlpp::value(std::optional{v}).as(cheese));
 
   static_assert(not sqlpp::has_data_type<decltype(v_not_null)>::value, "");
   static_assert(not sqlpp::has_data_type<decltype(v_maybe_null)>::value, "");

--- a/tests/core/types/operator/assign_expression.cpp
+++ b/tests/core/types/operator/assign_expression.cpp
@@ -40,7 +40,7 @@ using is_maybe_bool =
 template <typename Column, typename Value>
 void test_assign_expression(const Column& col, const Value& v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   using DataType = decltype(v_not_null);
   using OptDataType = decltype(v_maybe_null);

--- a/tests/core/types/operator/between_expression.cpp
+++ b/tests/core/types/operator/between_expression.cpp
@@ -40,7 +40,7 @@ using is_maybe_bool =
 template <typename Value>
 void test_between_expression(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Variations of nullable and non-nullable values
   static_assert(

--- a/tests/core/types/operator/bit_expression.cpp
+++ b/tests/core/types/operator/bit_expression.cpp
@@ -40,7 +40,7 @@ using is_maybe_integral =
 template <typename Value>
 void test_bit_expression(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Compare non-nullable with non-nullable.
   static_assert(is_integral<decltype(v_not_null << v_not_null)>::value, "");
@@ -115,9 +115,9 @@ void test_bit_expression(Value v) {
 template <typename Left, typename Right>
 void test_bit_shift_expression(Left l, Right r) {
   auto l_not_null = sqlpp::value(l);
-  auto l_maybe_null = sqlpp::value(std::make_optional(l));
+  auto l_maybe_null = sqlpp::value(std::optional{l});
   auto r_not_null = sqlpp::value(r);
-  auto r_maybe_null = sqlpp::value(std::make_optional(r));
+  auto r_maybe_null = sqlpp::value(std::optional{r});
 
   // Compare non-nullable with non-nullable.
   static_assert(is_integral<decltype(l_not_null << r_not_null)>::value, "");

--- a/tests/core/types/operator/case_expression.cpp
+++ b/tests/core/types/operator/case_expression.cpp
@@ -34,10 +34,10 @@ using is_same_type =
 template <typename Value>
 void test_case_expression(Value v) {
   auto c_not_null = sqlpp::value(true);
-  auto c_maybe_null = sqlpp::value(std::make_optional(false));
+  auto c_maybe_null = sqlpp::value(std::optional{false});
 
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = std::make_optional(sqlpp::value(v));
+  auto v_maybe_null = std::optional{sqlpp::value(v)};
 
   using DataType = decltype(v_not_null);
   using OptDataType = decltype(v_maybe_null);

--- a/tests/core/types/operator/comparison_expression.cpp
+++ b/tests/core/types/operator/comparison_expression.cpp
@@ -40,7 +40,7 @@ using is_maybe_bool =
 template <typename Value>
 void test_comparison_expression(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Compare non-nullable with non-nullable.
   static_assert(is_bool<decltype(v_not_null < v_not_null)>::value, "");
@@ -140,7 +140,7 @@ void test_comparison_expression(Value v) {
 template <typename Value>
 void test_like(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Compare non-nullable with non-nullable.
   static_assert(is_bool<decltype(like(v_not_null, v_not_null))>::value, "");

--- a/tests/core/types/operator/exists_expression.cpp
+++ b/tests/core/types/operator/exists_expression.cpp
@@ -36,7 +36,7 @@ void test_exists(Value v) {
   // Selectable values.
   const auto v_not_null = sqlpp::value(v).as(r_not_null);
   const auto v_maybe_null =
-      sqlpp::value(std::make_optional(v)).as(r_maybe_null);
+      sqlpp::value(std::optional{v}).as(r_maybe_null);
 
   // EXISTS expression can be used in basic comparison expressions, which use
   // remove_exists_t to look inside.

--- a/tests/core/types/operator/in_expression.cpp
+++ b/tests/core/types/operator/in_expression.cpp
@@ -40,7 +40,7 @@ void test_in_expression(Value v) {
   using OptValue = std::optional<Value>;
 
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Compare non-nullable with non-nullable.
   static_assert(
@@ -113,7 +113,7 @@ void test_in_expression(Value v) {
           sqlpp::detail::type_vector<L, R1>>::value,
       "");
   static_assert(std::is_same<sqlpp::nodes_of_t<decltype(in(
-                                 v_maybe_null, v, std::make_optional(v)))>,
+                                 v_maybe_null, v, std::optional{v}))>,
                              sqlpp::detail::type_vector<L, R1, R2>>::value,
                 "");
 }

--- a/tests/core/types/operator/logical_expression.cpp
+++ b/tests/core/types/operator/logical_expression.cpp
@@ -38,7 +38,7 @@ using is_maybe_bool =
 template <typename Value>
 void test_logical_expression(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Combine non-nullable with non-nullable.
   static_assert(is_bool<decltype(v_not_null and v_not_null)>::value, "");

--- a/tests/core/types/operator/sort_order_expression.cpp
+++ b/tests/core/types/operator/sort_order_expression.cpp
@@ -29,7 +29,7 @@
 template <typename Value>
 void test_order_expression(Value v) {
   auto v_not_null = sqlpp::value(v);
-  auto v_maybe_null = sqlpp::value(std::make_optional(v));
+  auto v_maybe_null = sqlpp::value(std::optional{v});
 
   // Sort order expressions have no value.
   static_assert(not sqlpp::has_data_type<decltype(v_not_null.asc())>::value,

--- a/tests/core/types/result_row.cpp
+++ b/tests/core/types/result_row.cpp
@@ -54,12 +54,12 @@ void test_result_row(Value v) {
   // Selectable values.
   auto v_not_null = sqlpp::value(v).as(r_not_null);
   const auto v_maybe_null =
-      sqlpp::value(std::make_optional(v)).as(r_maybe_null);
+      sqlpp::value(std::optional{v}).as(r_maybe_null);
 
   // Dynamically selectable values.
   const auto v_opt_not_null = dynamic(true, sqlpp::value(v).as(r_opt_not_null));
   const auto v_opt_maybe_null =
-      dynamic(true, sqlpp::value(std::make_optional(v)).as(r_opt_maybe_null));
+      dynamic(true, sqlpp::value(std::optional{v}).as(r_opt_maybe_null));
 
   auto s = select(v_not_null, v_maybe_null, v_opt_not_null, v_opt_maybe_null);
   using S = decltype(s);

--- a/tests/core/usage/Insert.cpp
+++ b/tests/core/usage/Insert.cpp
@@ -52,7 +52,7 @@ int Insert(int, char*[]) {
 
   db(insert_into(u).default_values());
   db(insert_into(t).set(t.boolNn = true, t.textN = "kirschauflauf"));
-  db(insert_into(t).set(t.boolNn = false, t.textN = std::make_optional("pie"),
+  db(insert_into(t).set(t.boolNn = false, t.textN = std::optional{"pie"},
                         t.intN = std::nullopt));
 
   to_sql_string(ctx, insert_into(t).default_values());
@@ -65,7 +65,7 @@ int Insert(int, char*[]) {
   multi_insert.add_values(t.boolNn = true, t.textN = "cheesecake", t.intN = 1);
   multi_insert.add_values(t.boolNn = false, t.textN = sqlpp::default_value,
                           t.intN = sqlpp::default_value);
-  multi_insert.add_values(t.boolNn = true, t.textN = std::make_optional("pie"),
+  multi_insert.add_values(t.boolNn = true, t.textN = std::optional{"pie"},
                           t.intN = std::nullopt);
   std::cerr << to_sql_string(ctx, multi_insert) << std::endl;
 
@@ -98,7 +98,7 @@ int Insert(int, char*[]) {
   prepared_insert.parameters.intN = std::nullopt;
   prepared_insert.parameters.intN = 17;
   prepared_insert.parameters.intN = std::nullopt;
-  prepared_insert.parameters.intN = std::make_optional(17);
+  prepared_insert.parameters.intN = std::optional{17};
   db(prepared_insert);
 
   auto prepared_insert_sv = db.prepare(insert_into(t).set(


### PR DESCRIPTION
This PR replaces `std::make_optional(expr)` `std::optional{expr}` as suggested in https://github.com/rbock/sqlpp23/issues/34

The project has been built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DDEPENDENCY_CHECK=ON
cmake --build build
cd build
ctest
```
All tests passed successfully.