### PR TITLE
Fix test dependency error

### DIFF
--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -82,7 +82,7 @@ if (${Python3_Interpreter_FOUND})
                         "--namespace" "test"
                         "--suppress-timestamp-warning"
                 DEPENDS "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
-                        "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
+                        "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp23-ddl2cpp"
                 VERBATIM)
 
             add_executable(sqlpp.scripts.compiled.${sample_name} ${sample_name}.cpp


### PR DESCRIPTION
This PR fixes a dependency error that appeared after ddl2cpp was renamed to sqlpp23-ddl2cpp. More information about the error can be found here https://github.com/rbock/sqlpp23/issues/30#issuecomment-3148759078