### PR TITLE
Fix warnings in the test code when building with GCC

### DIFF
--- a/tests/mysql/recipes/custom_function.cpp
+++ b/tests/mysql/recipes/custom_function.cpp
@@ -158,7 +158,7 @@ int main(int, char*[]) {
     auto a = cast("2001-01-01T00:00:00", as(sqlpp::timestamp{}));
     auto b = cast("2002-01-01T00:00:00", as(sqlpp::timestamp{}));
 
-    for (const auto [unit, expected_diff] : {
+    for (const auto& [unit, expected_diff] : {
              std::pair{example::timestamp_unit::year, 1},
              std::pair{example::timestamp_unit::month, 12},
              std::pair{example::timestamp_unit::day, 365},

--- a/tests/mysql/recipes/custom_function.cpp
+++ b/tests/mysql/recipes/custom_function.cpp
@@ -124,6 +124,8 @@ auto to_sql_string(Context&, example::timestamp_unit unit) {
       return "MINUTE";
     case example::timestamp_unit::second:
       return "SECOND";
+    default:
+      std::unreachable();
   };
 }
 


### PR DESCRIPTION
When building the library tests with GCC 15.1 without modules, there are a couple of warnings and one fatal link error. The latter occurs when the MySQL/MariaDB library is too old to support json.

The messages of the three commits in this PR provide details about the warning messages and the link error that occurred.

Also I think that after applying this PR to the `main` branch, it also makes sense to rebase the `module` branch on top of main, because these fixes are also relevant to the `module` branch.