### PR TITLE
Fix building the tests with GCC + modules

### DIFF
--- a/tests/include/sqlpp23/tests/core/connection_pool_tests.h
+++ b/tests/include/sqlpp23/tests/core/connection_pool_tests.h
@@ -176,13 +176,14 @@ void test_multiple_connections(Pool& pool) {
     auto pointers = std::unordered_set<void*>{};
     for (auto i = 0; i < 50; ++i) {
       connections.push_back(pool.get());
-      auto ir = pointers.insert(connections.back().native_handle());
+      auto& db = connections.back();
+      auto ir = pointers.insert(db.native_handle());
       if (!ir.second) {
         throw std::logic_error{
             "Pool yielded connection twice (without getting "
             "it back in between)"};
       }
-      connections.back()(insert_into(tabDept).default_values());
+      db(insert_into(tabDept).default_values());
     }
   } catch (const std::exception& e) {
     std::cerr << "Exception in " << __func__ << "\n";

--- a/tests/include/sqlpp23/tests/core/connection_pool_tests.h
+++ b/tests/include/sqlpp23/tests/core/connection_pool_tests.h
@@ -176,12 +176,12 @@ void test_multiple_connections(Pool& pool) {
     auto pointers = std::unordered_set<void*>{};
     for (auto i = 0; i < 50; ++i) {
       connections.push_back(pool.get());
-      if (pointers.count(connections.back().native_handle())) {
+      auto ir = pointers.insert(connections.back().native_handle());
+      if (!ir.second) {
         throw std::logic_error{
             "Pool yielded connection twice (without getting "
             "it back in between)"};
       }
-      pointers.insert(connections.back().native_handle());
       connections.back()(insert_into(tabDept).default_values());
     }
   } catch (const std::exception& e) {

--- a/tests/include/sqlpp23/tests/core/connection_pool_tests.h
+++ b/tests/include/sqlpp23/tests/core/connection_pool_tests.h
@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 #include <random>
-#include <set>
 #include <thread>
 #include <unordered_set>
 
@@ -174,7 +173,7 @@ void test_multiple_connections(Pool& pool) {
     ::test::TabDepartment tabDept = {};
     auto connections =
         std::vector<typename std::decay<decltype(pool.get())>::type>{};
-    auto pointers = std::set<void*>{};
+    auto pointers = std::unordered_set<void*>{};
     for (auto i = 0; i < 50; ++i) {
       connections.push_back(pool.get());
       if (pointers.count(connections.back().native_handle())) {

--- a/tests/include/sqlpp23/tests/mysql/all.h
+++ b/tests/include/sqlpp23/tests/mysql/all.h
@@ -31,8 +31,10 @@
 
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <print>
+#include <unordered_set>
 
 #include <sqlpp23/core/name/create_name_tag.h>
 #include <sqlpp23/tests/core/assert_throw.h>

--- a/tests/include/sqlpp23/tests/postgresql/all.h
+++ b/tests/include/sqlpp23/tests/postgresql/all.h
@@ -31,8 +31,10 @@
 
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <print>
+#include <unordered_set>
 
 #include <libpq-fe.h>
 

--- a/tests/include/sqlpp23/tests/sqlite3/all.h
+++ b/tests/include/sqlpp23/tests/sqlite3/all.h
@@ -31,8 +31,10 @@
 
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <print>
+#include <unordered_set>
 
 #include <sqlpp23/core/name/create_name_tag.h>
 #include <sqlpp23/tests/core/assert_throw.h>


### PR DESCRIPTION
This is the second PR that fixes building the projects with GCC + tests + modules support.

After applying the changes in this PR GCC 15.1 builds all the tests, but the Date & Time tests of each connector (PostgreSQL, MySQL, SQLite3) fail.

I suspect that this is caused by the fact that due to this [gcc bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114795#c3) some of the standard library code is duplicates thus violating the ODR. In some cases violating the ODR causes redefinition errors during linking, but in our case we get more subtle bugs.

Most likely this bug can be worked around just like we did for the redefinition errors (by including the right standard header in the all.h).

Until the work around is added to the PR, I will keep it as a draft.