### PR TITLE
ddl2cpp code cleanup

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -277,7 +277,7 @@ def createDdlParser():
         + pp.ZeroOrMore(
             ddlUnsigned
             | ddlNotNull
-            | pp.CaselessKeyword("null")
+            | pp.Suppress(pp.CaselessKeyword("null"))
             | ddlAutoValue
             | ddlDefaultValue
             | ddlGeneratedValue
@@ -290,9 +290,9 @@ def createDdlParser():
     # CREATE TABLE parser
     ddlCreateTable = (
         pp.Group(
-            pp.CaselessKeyword("CREATE")
+            pp.Suppress(pp.CaselessKeyword("CREATE"))
             + pp.Suppress(pp.Optional(pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")))
-            + pp.CaselessKeyword("TABLE")
+            + pp.Suppress(pp.CaselessKeyword("TABLE"))
             + pp.Suppress(pp.Optional(pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")))
             + ddlName.setResultsName("tableName")
             + ddlLeft

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -277,7 +277,7 @@ def createDdlParser():
         + pp.ZeroOrMore(
             ddlUnsigned
             | ddlNotNull
-            | pp.Suppress(pp.CaselessKeyword("null"))
+            | pp.Suppress(pp.CaselessKeyword("NULL"))
             | ddlAutoValue
             | ddlDefaultValue
             | ddlGeneratedValue

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -234,9 +234,7 @@ def createDdlParser():
         + pp.CaselessKeyword("zone")
     )
 
-    ddlNotNull = pp.Group(
-        pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")
-    ).setResultsName("notNull")
+    ddlNotNull = pp.Group(pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")).setResultsName("notNull")
     ddlDefaultValue = pp.CaselessKeyword("DEFAULT").setResultsName("hasDefaultValue")
 
     ddlGeneratedValue = pp.CaselessKeyword("GENERATED").setResultsName("hasGeneratedValue")
@@ -247,9 +245,7 @@ def createDdlParser():
     ]
     ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True))).setResultsName("hasAutoValue")
 
-    ddlPrimaryKey = pp.Group(
-        pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")
-    ).setResultsName("isPrimaryKey")
+    ddlPrimaryKey = pp.Group(pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")).setResultsName("isPrimaryKey")
 
     ddlIgnoredKeywords = [
         "CONSTRAINT",
@@ -296,9 +292,7 @@ def createDdlParser():
             + pp.Suppress(pp.Optional(pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")))
             + ddlName.setResultsName("tableName")
             + ddlLeft
-            + pp.Group(pp.delimitedList(pp.Suppress(ddlConstraint) | ddlColumn)).setResultsName(
-                "columns"
-            )
+            + pp.Group(pp.delimitedList(pp.Suppress(ddlConstraint) | ddlColumn)).setResultsName("columns")
             + ddlRight
         )
         .setParseAction(addCreateSql)

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -270,8 +270,8 @@ def createDdlParser():
     ).setResultsName("isConstraint")
 
     ddlColumn = pp.Group(
-        ddlName("name")
-        + ddlType("type")
+        ddlName.setResultsName("name")
+        + ddlType.setResultsName("type")
         + pp.Suppress(pp.Optional(ddlWidth))
         + pp.Suppress(pp.Optional(ddlTimezone))
         + pp.ZeroOrMore(

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -288,18 +288,12 @@ def createDdlParser():
     )
 
     # CREATE TABLE parser
-    ddlIfNotExists = pp.Group(
-        pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")
-    ).setResultsName("ifNotExists")
-    ddlOrReplace = pp.Group(
-        pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")
-    ).setResultsName("orReplace")
     ddlCreateTable = (
         pp.Group(
             pp.CaselessKeyword("CREATE")
-            + pp.Suppress(pp.Optional(ddlOrReplace))
+            + pp.Suppress(pp.Optional(pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")))
             + pp.CaselessKeyword("TABLE")
-            + pp.Suppress(pp.Optional(ddlIfNotExists))
+            + pp.Suppress(pp.Optional(pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")))
             + ddlName.setResultsName("tableName")
             + ddlLeft
             + pp.Group(pp.delimitedList(pp.Suppress(ddlConstraint) | ddlColumn)).setResultsName(

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -155,10 +155,6 @@ ddlTimeTypes = [
 ]
 
 
-def addCreateSql(text, loc, parsed):
-    parsed.create["createSql"] = text
-
-
 # Init the DDL parser
 def createDdlParser():
     global ddl
@@ -284,6 +280,8 @@ def createDdlParser():
     )
 
     # CREATE TABLE parser
+    def addCreateSql(text, loc, parsed):
+        parsed.create["createSql"] = text
     ddlCreateTable = (
         pp.Group(
             pp.Suppress(pp.CaselessKeyword("CREATE"))

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -70,7 +70,7 @@ ddlExpression = pp.OneOrMore(
 ddlBracedArguments << ddlLeft + pp.delimitedList(ddlExpression) + ddlRight
 ddlBracedExpression << ddlLeft + ddlExpression + ddlRight
 
-ddlArguments = pp.Suppress(pp.Group(pp.delimitedList(ddlExpression)))
+ddlArguments = pp.Suppress(pp.delimitedList(ddlExpression))
 ddlFunctionCall << ddlName + ddlLeft + pp.Optional(ddlArguments) + ddlRight
 
 # Data types
@@ -234,7 +234,7 @@ def createDdlParser():
         + pp.CaselessKeyword("zone")
     )
 
-    ddlNotNull = pp.Group(pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")).setResultsName("notNull")
+    ddlNotNull = (pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")).setResultsName("notNull")
     ddlDefaultValue = pp.CaselessKeyword("DEFAULT").setResultsName("hasDefaultValue")
 
     ddlGeneratedValue = pp.CaselessKeyword("GENERATED").setResultsName("hasGeneratedValue")
@@ -245,7 +245,7 @@ def createDdlParser():
     ]
     ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True))).setResultsName("hasAutoValue")
 
-    ddlPrimaryKey = pp.Group(pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")).setResultsName("isPrimaryKey")
+    ddlPrimaryKey = (pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")).setResultsName("isPrimaryKey")
 
     ddlIgnoredKeywords = [
         "CONSTRAINT",
@@ -257,7 +257,7 @@ def createDdlParser():
         "CHECK",
         "PERIOD",
     ]
-    ddlConstraint = pp.Group(
+    ddlConstraint = (
         pp.Or(map(
             pp.CaselessKeyword,
             sorted(ddlIgnoredKeywords + ["PRIMARY"], reverse=True)


### PR DESCRIPTION
This PR performs a few minor cleanups of of the code of ddl2cpp:

- Removes superfluous calls to `pp.Group()`.
- Suppresses (`pp.Suppress()`) the generation of tokens that are not being used.
- Changes all calls to `setResultsName()` to explicit ones instead of using `operator()`.
- Make `addCreateSql()` an inner function of `createDdlParser()`.
- Other small code formatting fixes.