### PR TITLE
tests: Don't try to use std::ranges::views::enumerate with libc++

### DIFF
--- a/tests/core/usage/statement/select.cpp
+++ b/tests/core/usage/statement/select.cpp
@@ -77,10 +77,14 @@ int main(int, char*[]) {
                        std::ranges::to<std::vector>();
     }
 
+    // As of now libc++ does not support std::ranges::views::enumerate
+    // For details see: https://libcxx.llvm.org/Status/Cxx23.html
+#ifndef _LIBCPP_VERSION
     for ([[maybe_unused]] const auto& [index, row] :
          db(select(foo.id).from(foo)) | std::ranges::views::enumerate) {
       // do something with index and row
     }
+#endif
 
   } catch (const std::exception& e) {
     std::cerr << "Exception: " << e.what() << std::endl;


### PR DESCRIPTION
As mentioned [here](https://github.com/rbock/sqlpp23/issues/64#issuecomment-3335749461), it seems that tests/core/usage/statement/select.cpp fails to build with libc++ because the latter does not have std::ranges::views::enumerate yet.

This PR wraps the code using std::ranges::views::enumerate in an #ifndef to prevent it from being compiled with libc++.