### PR TITLE
tests: Fix custom command dependecies

### DIFF
--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -74,7 +74,7 @@ if (${Python3_Interpreter_FOUND})
                 set(naming_style camel-case)
             endif()
             add_custom_command(
-                OUTPUT "${sqlpp.scripts.generated.sample.include}.h"
+                OUTPUT "${sqlpp.scripts.generated.sample.include}"
                 COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp23-ddl2cpp"
                         "--path-to-ddl" "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
                         "--path-to-header" "${sqlpp.scripts.generated.sample.include}"
@@ -86,7 +86,7 @@ if (${Python3_Interpreter_FOUND})
                 VERBATIM)
 
             add_executable(sqlpp.scripts.compiled.${sample_name} ${sample_name}.cpp
-                "${sqlpp.scripts.generated.sample.include}.h")
+                "${sqlpp.scripts.generated.sample.include}")
             target_link_libraries(sqlpp.scripts.compiled.${sample_name} PRIVATE sqlpp23)
         endforeach()
 

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -105,20 +105,20 @@ if (${Python3_Interpreter_FOUND})
 
         # Custom types defined in a CSV file
         set(custom_type_sql "ddl2cpp_sample_good_custom_type")
-        set(sqlpp.scripts.generated.custom_type_sql.include "${CMAKE_CURRENT_BINARY_DIR}/${custom_type_sql}")
+        set(sqlpp.scripts.generated.custom_type_sql.include "${CMAKE_CURRENT_BINARY_DIR}/${custom_type_sql}.h")
         add_custom_command(
-            OUTPUT "${sqlpp.scripts.generated.custom_type_sql.include}.h"
+            OUTPUT "${sqlpp.scripts.generated.custom_type_sql.include}"
             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp23-ddl2cpp"
                     "--path-to-datatype-file=${CMAKE_CURRENT_LIST_DIR}/custom_types.csv"
                     "--path-to-ddl" "${CMAKE_CURRENT_LIST_DIR}/${custom_type_sql}.sql"
-                    "--path-to-header" "${sqlpp.scripts.generated.custom_type_sql.include}.h"
+                    "--path-to-header" "${sqlpp.scripts.generated.custom_type_sql.include}"
                     "--namespace" "test"
                     "--suppress-timestamp-warning"
             DEPENDS "${CMAKE_CURRENT_LIST_DIR}/${custom_type_sql}.sql"
                     "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp23-ddl2cpp"
             VERBATIM)
         add_executable(sqlpp.scripts.compiled.${custom_type_sql} ${custom_type_sql}.cpp
-            "${sqlpp.scripts.generated.custom_type_sql.include}.h")
+            "${sqlpp.scripts.generated.custom_type_sql.include}")
         target_link_libraries(sqlpp.scripts.compiled.${custom_type_sql} PRIVATE sqlpp23)
     endif()
 endif()


### PR DESCRIPTION
This PR fixes a bug which caused two targets to be always rebuilt.

A couple of custom commands had invalid filenames listed as their dependencies (`sample.h.h` and `sample_identity_naming.h.h`). This caused the two custom commands to be run always.

How to reproduce the bug:

Run
```
cmake -B build -G Ninja -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DDEPENDENCY_CHECK=ON
````

Then run multiple times
```
cmake --build build
```

Each time the two targets will be rebuilt

The PR removes the superfluous `.h` suffixes and thus fixes the bug.