### PR TITLE
tests: Add <algorithm> header to Blob.cpp and Select.cpp test files

### DIFF
--- a/tests/core/usage/Select.cpp
+++ b/tests/core/usage/Select.cpp
@@ -24,6 +24,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+
 #include <sqlpp23/tests/core/all.h>
 
 struct to_cerr {

--- a/tests/postgresql/usage/Blob.cpp
+++ b/tests/postgresql/usage/Blob.cpp
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <functional>
 #include <random>
 

--- a/tests/sqlite3/usage/Blob.cpp
+++ b/tests/sqlite3/usage/Blob.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <functional>
 #include <random>
 


### PR DESCRIPTION
These tests use `std::for_each` (Select.cpp) or `std::generate_n` (Blob.cpp) which are both in `algorithm`. Without explicit include, the build with modules fails to compile. This PR adds the necessary includes.