### PR TITLE
tests: Implement enumerate-like functionality using zip and iota

### DIFF
--- a/tests/core/usage/statement/select.cpp
+++ b/tests/core/usage/statement/select.cpp
@@ -85,6 +85,11 @@ int main(int, char*[]) {
       // do something with index and row
     }
 #endif
+    // We can use zip with iota to create enumerate-like functionality
+    for ([[maybe_unused]] const auto& [index, row] :
+         std::ranges::views::zip(std::views::iota(0uz), db(select(foo.id).from(foo)))) {
+      // do something with index and row
+    }
 
   } catch (const std::exception& e) {
     std::cerr << "Exception: " << e.what() << std::endl;


### PR DESCRIPTION
This PR adds a zip with iota example for enumerate-like functionality, which compiles on clang when no enumerate is present. Same as https://github.com/wdconinc/sqlpp23/pull/3, and as discussed in #64 and #65.