### PR TITLE
ddl2cpp: Fix names of generated table creation helpers

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -703,8 +703,9 @@ def writeTable(table, header, args):
     tableTemplateParameters = ""
     tableRequiredInsertColumns = ""
     if args.generate_table_creation_helper:
+        creationHelperFunc = "create" + ("" if args.naming_style == "camel-case" else "_") + tableClass
         print("  " + export + "template<typename Db>", file=header)
-        print("  void create" + tableClass + "(Db& db) {", file=header)
+        print("  void " + creationHelperFunc + "(Db& db) {", file=header)
         print("    db(R\"+++(DROP TABLE IF EXISTS " + sqlTableName + ")+++\");", file=header)
         print("    db(R\"+++(" + create.createSql + ")+++\");", file=header)
         print("  }", file=header)

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -703,12 +703,12 @@ def writeTable(table, header, args):
     tableTemplateParameters = ""
     tableRequiredInsertColumns = ""
     if args.generate_table_creation_helper:
-      print("  " + export + "template<typename Db>", file=header)
-      print("  void create" + tableClass + "(Db& db) {", file=header)
-      print("    db(R\"+++(DROP TABLE IF EXISTS " + sqlTableName + ")+++\");", file=header)
-      print("    db(R\"+++(" + create.createSql + ")+++\");", file=header)
-      print("  }", file=header)
-      print("", file=header)
+        print("  " + export + "template<typename Db>", file=header)
+        print("  void create" + tableClass + "(Db& db) {", file=header)
+        print("    db(R\"+++(DROP TABLE IF EXISTS " + sqlTableName + ")+++\");", file=header)
+        print("    db(R\"+++(" + create.createSql + ")+++\");", file=header)
+        print("  }", file=header)
+        print("", file=header)
     print("  " + export + "struct " + tableSpec + " {", file=header)
     for column in create.columns:
         if column.isConstraint:


### PR DESCRIPTION
This PR adds a missing underscore to the names of the generated table creation helpers when naming style is set to `identity`.

How to reproduce: Create table.sql that contains:
```
CREATE TABLE my_tbl (col int PRIMARY KEY);
```

Run:
```
sqlpp23-ddl2cpp --path-to-ddl table.sql --namespace model --path-to-header model.h --generate-table-creation-helper --naming-style identity
```

The generated table creation helper is called `createmy_tbl` while the correct function name should really be `create_my_tbl`. So this PR adds the missing underscore to the names of the generated table creation helpers when `--naming-style identity` is specified.