### PR TITLE
ddl2cpp bugfixes

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -301,6 +301,7 @@ def createDdlParser():
 
     ddlComment = pp.oneOf(["--", "#"]) + pp.restOfLine
     ddl.ignore(ddlComment)
+    ddl.parseWithTabs()
     return ddl
 
 def testBoolean():


### PR DESCRIPTION
After putting on hold https://github.com/rbock/sqlpp23/pull/71 I decided to submit separately just the bugfixes to ddl2cpp. So this PR provides the following fixes:

- https://github.com/rbock/sqlpp23/pull/62) introduced a bug that broke the creation of split headers. This PR also fixes this newly introduced bug.
- https://github.com/rbock/sqlpp23/pull/62) introduced a bug that caused incorrect SQL commands to be emitted for the table creation helper functions. This PR also fixes this newly introduced bug.
- Disabled expansion of tabs into spaces. By default pyparsing expands tabs into spaces in the input text. In our case this is clearly unwanted behavior because it could cause the generation of incorrect table creation helpers. For example the following table definition `CREATE TABLE tbl (mytext text NOT NULL DEFAULT '\t\t')` would have the tabs expanded during parsing and the wrong table creation code would be emitted (the default value would have spaces instead of tabs).