### PR TITLE
ddl2cpp: Cleanup part 3

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -679,12 +679,11 @@ class ModelWriter:
             "  " + export + "using " + tableClass + " = ::sqlpp::table_t<" + tableSpec + ">;", file=header)
         print("", file=header)
         if DataTypeError:
-            print("Error: unsupported datatypes.")
+            print("Error: unsupported SQL data type(s).")
             print("Possible solutions:")
-            print("A) Implement this datatype (examples: sqlpp23/data_types)")
-            print("B) Use the '{dataTypeFileArg}' command line argument to map the type to a known type (example: README)")
-            print("C) Extend/upgrade sqlpp23-ddl2cpp (edit types map)")
-            print("D) Raise an issue on github")
+            print("A) Use the '--path-to-datatype-file' command line argument to map the SQL data type to a known sqlpp23 data type (example: README)")
+            print("B) Implement this data type in sqlpp23 (examples: sqlpp23/data_types) and in sqlpp23-ddl2cpp")
+            print("C) Raise an issue on github")
             sys.exit(ExitCode.BAD_DATA_TYPE)  # return non-zero error code, we might need it for automation
 
     @classmethod

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -273,6 +273,15 @@ class DdlParser:
         cls.ddl.ignore(ddlComment)
         cls.ddl.parseWithTabs()
 
+    @classmethod
+    def parse_ddls(cls, ddl_paths):
+        try:
+            return [cls.ddl.parseFile(path) for path in ddl_paths]
+        except pp.ParseException as e:
+            print("ERROR: failed to parse " + path)
+            print(e.explain(1))
+            sys.exit(ExitCode.STRANGE_PARSING)
+
 
 class SelfTest:
     """Runs a self-test of the parser"""
@@ -773,15 +782,6 @@ def get_extended_types(filename):
         return types
 
 
-def parseDdls(args):
-    try:
-        return [DdlParser.ddl.parseFile(path) for path in args.path_to_ddl]
-    except pp.ParseException as e:
-        print("ERROR: failed to parse " + path)
-        print(e.explain(1))
-        sys.exit(ExitCode.STRANGE_PARSING)
-
-
 if __name__ == "__main__":
     args = parseCommandlineArgs()
 
@@ -790,6 +790,6 @@ if __name__ == "__main__":
     else:
         customTypes = get_extended_types(args.path_to_datatype_file)
         DdlParser.initialize(customTypes)
-        parsedDdls = parseDdls(args)
+        parsedDdls = DdlParser.parse_ddls(args.path_to_ddl)
         ModelWriter.write(parsedDdls, args)
     sys.exit(ExitCode.SUCCESS)

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -39,6 +39,11 @@ class ExitCode:
     STRANGE_PARSING = 20
 
 
+# DdlParser, SelfTest and ModelWriter could be modules instead of classes. However, using
+# modules implies that the program code would be split into several files and we want to avoid that
+# because it would complicate program installation. That is why we use classes.
+
+
 class DdlParser:
     """Rather crude SQL expression parser.
     This is not geared at correctly interpreting SQL, but at identifying (and ignoring) expressions for instance in DEFAULT expressions

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -39,270 +39,253 @@ class ExitCode:
     STRANGE_PARSING = 20
 
 
-# Rather crude SQL expression parser.
-# This is not geared at correctly interpreting SQL, but at identifying (and ignoring) expressions for instance in DEFAULT expressions
-ddlLeft, ddlRight = map(pp.Suppress, "()")
-ddlNumber = pp.Word(pp.nums + "+-.", pp.nums + "+-.Ee")
-ddlString = (
-    pp.QuotedString("'") | pp.QuotedString('"', escQuote='""') | pp.QuotedString("`")
-)
-# ddlString.setDebug(True) #uncomment to debug pyparsing
-ddlTerm = pp.Word(pp.alphas + "_", pp.alphanums + "_.$")
-ddlName = pp.Or([ddlTerm, ddlString, pp.Combine(ddlString + "." + ddlString), pp.Combine(ddlTerm + ddlString)])
-ddlOperator = pp.Or(
-    map(pp.CaselessLiteral, ["+", "-", "*", "/", "<", "<=", ">", ">=", "=", "%"]),
-    pp.CaselessKeyword("DIV")
-)
+class DdlParser:
+    """Rather crude SQL expression parser.
+    This is not geared at correctly interpreting SQL, but at identifying (and ignoring) expressions for instance in DEFAULT expressions
+    """
 
-ddlBracedExpression = pp.Forward()
-ddlFunctionCall = pp.Forward()
-ddlCastEnd = "::" + ddlTerm
-ddlCast = ddlString + ddlCastEnd
-ddlBracedArguments = pp.Forward()
-ddlExpression = pp.OneOrMore(
-    ddlBracedExpression
-    | ddlFunctionCall
-    | ddlCastEnd
-    | ddlCast
-    | ddlOperator
-    | ddlString
-    | ddlTerm
-    | ddlNumber
-    | ddlBracedArguments
-)
-
-ddlBracedArguments << ddlLeft + pp.delimitedList(ddlExpression) + ddlRight
-ddlBracedExpression << ddlLeft + ddlExpression + ddlRight
-
-ddlArguments = pp.Suppress(pp.delimitedList(ddlExpression))
-ddlFunctionCall << ddlName + ddlLeft + pp.Optional(ddlArguments) + ddlRight
-
-# Data types
-ddlBooleanTypes = [
-    "bool",
-    "boolean",
-]
-
-ddlIntegerTypes = [
-    "bigint",
-    "int",
-    "int2",  # PostgreSQL
-    "int4",  # PostgreSQL
-    "int8",  # PostgreSQL
-    "integer",
-    "mediumint",
-    "smallint",
-    "tinyint",
-]
-
-ddlSerialTypes = [
-    "bigserial",  # PostgreSQL
-    "serial",  # PostgreSQL
-    "serial2",  # PostgreSQL
-    "serial4",  # PostgreSQL
-    "serial8",  # PostgreSQL
-    "smallserial",  # PostgreSQL
-]
-
-ddlFloatingPointTypes = [
-    "decimal",  # MYSQL
-    "double",
-    "float8",  # PostgreSQL
-    "float",
-    "float4",  # PostgreSQL
-    "numeric",  # PostgreSQL
-    "real",
-]
-
-ddlTextTypes = [
-    "char",
-    "varchar",
-    "character varying",  # PostgreSQL
-    "text",
-    "clob",
-    "enum",  # MYSQL
-    "set",
-    "longtext",  # MYSQL
-    "jsonb",  # PostgreSQL
-    "json",  # PostgreSQL
-    "tinytext",  # MYSQL
-    "mediumtext",  # MYSQL
-    "rational", # PostgreSQL pg_rationale extension
-]
-
-ddlBlobTypes = [
-    "bytea",
-    "tinyblob",
-    "blob",
-    "mediumblob",
-    "longblob",
-    "binary",  # MYSQL
-    "varbinary",  # MYSQL
-]
-
-ddlDateTypes = [
-    "date",
-]
-
-ddlDateTimeTypes = [
-    "datetime",
-    "timestamp",
-    "timestamp without time zone",  # PostgreSQL
-    "timestamp with time zone",  # PostgreSQL
-    "timestamptz",  # PostgreSQL
-]
-
-ddlTimeTypes = [
-    "time",
-    "time without time zone",  # PostgreSQL
-    "time with time zone",  # PostgreSQL
-]
-
-
-# Init the DDL parser
-def createDdlParser():
-    global ddl
-    global ddlType
-    global ddlColumn
-    global ddlConstraint
-    global ddlCtWithSql
-    # Column and constraint parsers
-
-    ddlBoolean = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlBooleanTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("boolean"))
-
-    ddlInteger = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlIntegerTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("integral"))
-
-    ddlSerial = (
-        pp.Or(map(pp.CaselessKeyword, sorted(ddlSerialTypes, reverse=True)))
-        .setParseAction(pp.replaceWith("integral"))
-        .setResultsName("hasSerialValue")
-    )
-
-    ddlFloatingPoint = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlFloatingPointTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("floating_point"))
-
-    ddlText = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlTextTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("text"))
-
-
-    ddlBlob = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlBlobTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("blob"))
-
-    ddlDate = (
-        pp.Or(map(pp.CaselessKeyword, sorted(ddlDateTypes, reverse=True)))
-        .setParseAction(pp.replaceWith("date"))
-        .setResultsName("warnTimezone")
-    )
-
-    ddlDateTime = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlDateTimeTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("timestamp"))
-
-    ddlTime = pp.Or(
-        map(pp.CaselessKeyword, sorted(ddlTimeTypes, reverse=True))
-    ).setParseAction(pp.replaceWith("time"))
-
-    ddlUnknown = pp.Word(pp.alphanums).setParseAction(pp.replaceWith("UNKNOWN"))
-
-    ddlType = (
-        ddlBoolean
-        | ddlInteger
-        | ddlSerial
-        | ddlFloatingPoint
-        | ddlText
-        | ddlBlob
-        | ddlDateTime
-        | ddlDate
-        | ddlTime
-        | ddlUnknown
-    )
-
-    ddlUnsigned = pp.CaselessKeyword("UNSIGNED").setResultsName("isUnsigned")
-    ddlDigits = "," + pp.Word(pp.nums)
-    ddlWidth = ddlLeft + pp.Word(pp.nums) + pp.Optional(ddlDigits) + ddlRight
-    ddlTimezone = (
-        (pp.CaselessKeyword("with") | pp.CaselessKeyword("without"))
-        + pp.CaselessKeyword("time")
-        + pp.CaselessKeyword("zone")
-    )
-
-    ddlNotNull = (pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")).setResultsName("notNull")
-    ddlDefaultValue = pp.CaselessKeyword("DEFAULT").setResultsName("hasDefaultValue")
-
-    ddlGeneratedValue = pp.CaselessKeyword("GENERATED").setResultsName("hasGeneratedValue")
-
-    ddlAutoKeywords = [
-        "AUTO_INCREMENT",
-        "AUTOINCREMENT"
+    # Names of data types that can be updated by the custom data types
+    ddlBooleanTypes = [
+        "bool",
+        "boolean",
     ]
-    ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True))).setResultsName("hasAutoValue")
-
-    ddlPrimaryKey = (pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")).setResultsName("isPrimaryKey")
-
-    ddlIgnoredKeywords = [
-        "CONSTRAINT",
-        "FOREIGN",
-        "KEY",
-        "FULLTEXT",
-        "INDEX",
-        "UNIQUE",
-        "CHECK",
-        "PERIOD",
+    ddlIntegerTypes = [
+        "bigint",
+        "int",
+        "int2",  # PostgreSQL
+        "int4",  # PostgreSQL
+        "int8",  # PostgreSQL
+        "integer",
+        "mediumint",
+        "smallint",
+        "tinyint",
     ]
-    ddlConstraint = (
-        pp.Or(map(
-            pp.CaselessKeyword,
-            sorted(ddlIgnoredKeywords + ["PRIMARY"], reverse=True)
-        ))
-        + ddlExpression
-    ).setResultsName("isConstraint")
+    ddlSerialTypes = [
+        "bigserial",  # PostgreSQL
+        "serial",  # PostgreSQL
+        "serial2",  # PostgreSQL
+        "serial4",  # PostgreSQL
+        "serial8",  # PostgreSQL
+        "smallserial",  # PostgreSQL
+    ]
+    ddlFloatingPointTypes = [
+        "decimal",  # MYSQL
+        "double",
+        "float8",  # PostgreSQL
+        "float",
+        "float4",  # PostgreSQL
+        "numeric",  # PostgreSQL
+        "real",
+    ]
+    ddlTextTypes = [
+        "char",
+        "varchar",
+        "character varying",  # PostgreSQL
+        "text",
+        "clob",
+        "enum",  # MYSQL
+        "set",
+        "longtext",  # MYSQL
+        "jsonb",  # PostgreSQL
+        "json",  # PostgreSQL
+        "tinytext",  # MYSQL
+        "mediumtext",  # MYSQL
+        "rational", # PostgreSQL pg_rationale extension
+    ]
+    ddlBlobTypes = [
+        "bytea",
+        "tinyblob",
+        "blob",
+        "mediumblob",
+        "longblob",
+        "binary",  # MYSQL
+        "varbinary",  # MYSQL
+    ]
+    ddlDateTypes = [
+        "date",
+    ]
+    ddlDateTimeTypes = [
+        "datetime",
+        "timestamp",
+        "timestamp without time zone",  # PostgreSQL
+        "timestamp with time zone",  # PostgreSQL
+        "timestamptz",  # PostgreSQL
+    ]
+    ddlTimeTypes = [
+        "time",
+        "time without time zone",  # PostgreSQL
+        "time with time zone",  # PostgreSQL
+    ]
 
-    ddlColumn = pp.Group(
-        ddlName.setResultsName("name")
-        + ddlType.setResultsName("type")
-        + pp.Suppress(pp.Optional(ddlWidth))
-        + pp.Suppress(pp.Optional(ddlTimezone))
-        + pp.ZeroOrMore(
-            ddlUnsigned
-            | ddlNotNull
-            | pp.Suppress(pp.CaselessKeyword("NULL"))
-            | ddlAutoValue
-            | ddlDefaultValue
-            | ddlGeneratedValue
-            | ddlPrimaryKey
-            | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessKeyword, sorted(ddlIgnoredKeywords, reverse=True)))))
-            | pp.Suppress(ddlExpression)
+    # Parsers that are initialized later
+    ddlExpression = None
+    ddlType = None
+    ddlColumn = None
+    ddlConstraint = None
+    ddlCtWithSql = None
+    ddl = None
+
+    @classmethod
+    def initialize(cls):
+        """Initialize the DDL parser"""
+
+        # Basic parsers
+        ddlLeft = pp.Suppress("(")
+        ddlRight = pp.Suppress(")")
+        ddlNumber = pp.Word(pp.nums + "+-.", pp.nums + "+-.Ee")
+        ddlString = (
+            pp.QuotedString("'") | pp.QuotedString('"', escQuote='""') | pp.QuotedString("`")
         )
-    )
+        # ddlString.setDebug(True) #uncomment to debug pyparsing
+        ddlTerm = pp.Word(pp.alphas + "_", pp.alphanums + "_.$")
+        ddlName = pp.Or([ddlTerm, ddlString, pp.Combine(ddlString + "." + ddlString), pp.Combine(ddlTerm + ddlString)])
+        ddlOperator = pp.Or(
+            map(pp.CaselessLiteral, ["+", "-", "*", "/", "<", "<=", ">", ">=", "=", "%"]),
+            pp.CaselessKeyword("DIV")
+        )
+        ddlBracedExpression = pp.Forward()
+        ddlFunctionCall = pp.Forward()
+        ddlCastEnd = "::" + ddlTerm
+        ddlCast = ddlString + ddlCastEnd
+        ddlBracedArguments = pp.Forward()
+        cls.ddlExpression = pp.OneOrMore(
+            ddlBracedExpression
+            | ddlFunctionCall
+            | ddlCastEnd
+            | ddlCast
+            | ddlOperator
+            | ddlString
+            | ddlTerm
+            | ddlNumber
+            | ddlBracedArguments
+        )
+        ddlBracedArguments << ddlLeft + pp.delimitedList(cls.ddlExpression) + ddlRight
+        ddlBracedExpression << ddlLeft + cls.ddlExpression + ddlRight
+        ddlArguments = pp.Suppress(pp.delimitedList(cls.ddlExpression))
+        ddlFunctionCall << ddlName + ddlLeft + pp.Optional(ddlArguments) + ddlRight
 
-    # CREATE TABLE parser
-    ddlCtBasic = (
-        pp.Suppress(pp.CaselessKeyword("CREATE"))
-        + pp.Suppress(pp.Optional(pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")))
-        + pp.Suppress(pp.CaselessKeyword("TABLE"))
-        + pp.Suppress(pp.Optional(pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")))
-        + ddlName.setResultsName("tableName")
-        + ddlLeft
-        + pp.Group(pp.delimitedList(pp.Suppress(ddlConstraint) | ddlColumn)).setResultsName("columns")
-        + ddlRight
-    )
-    def addCreateSql(text, loc, tokens):
-        create = tokens.create
-        create.value["createSql"] = text[create.locn_start:create.locn_end]
-    ddlCtWithSql = pp.Located(ddlCtBasic).setResultsName("create").setParseAction(addCreateSql)
-    ddl = pp.OneOrMore(pp.Group(pp.Suppress(pp.SkipTo(ddlCtBasic, False)) + ddlCtWithSql)).setResultsName("tables")
+        # Data type parsers
+        ddlBoolean = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlBooleanTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("boolean"))
+        ddlInteger = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlIntegerTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("integral"))
+        ddlSerial = (
+            pp.Or(map(pp.CaselessKeyword, sorted(cls.ddlSerialTypes, reverse=True)))
+            .setParseAction(pp.replaceWith("integral"))
+            .setResultsName("hasSerialValue")
+        )
+        ddlFloatingPoint = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlFloatingPointTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("floating_point"))
+        ddlText = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlTextTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("text"))
+        ddlBlob = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlBlobTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("blob"))
+        ddlDate = (
+            pp.Or(map(pp.CaselessKeyword, sorted(cls.ddlDateTypes, reverse=True)))
+            .setParseAction(pp.replaceWith("date"))
+            .setResultsName("warnTimezone")
+        )
+        ddlDateTime = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlDateTimeTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("timestamp"))
+        ddlTime = pp.Or(
+            map(pp.CaselessKeyword, sorted(cls.ddlTimeTypes, reverse=True))
+        ).setParseAction(pp.replaceWith("time"))
+        ddlUnknown = pp.Word(pp.alphanums).setParseAction(pp.replaceWith("UNKNOWN"))
+        cls.ddlType = (
+            ddlBoolean
+            | ddlInteger
+            | ddlSerial
+            | ddlFloatingPoint
+            | ddlText
+            | ddlBlob
+            | ddlDateTime
+            | ddlDate
+            | ddlTime
+            | ddlUnknown
+        )
 
-    ddlComment = pp.oneOf(["--", "#"]) + pp.restOfLine
-    ddl.ignore(ddlComment)
-    ddl.parseWithTabs()
-    return ddl
+        # Constraints parser
+        ddlUnsigned = pp.CaselessKeyword("UNSIGNED").setResultsName("isUnsigned")
+        ddlDigits = "," + pp.Word(pp.nums)
+        ddlWidth = ddlLeft + pp.Word(pp.nums) + pp.Optional(ddlDigits) + ddlRight
+        ddlTimezone = (
+            (pp.CaselessKeyword("with") | pp.CaselessKeyword("without"))
+            + pp.CaselessKeyword("time")
+            + pp.CaselessKeyword("zone")
+        )
+        ddlNotNull = (pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")).setResultsName("notNull")
+        ddlDefaultValue = pp.CaselessKeyword("DEFAULT").setResultsName("hasDefaultValue")
+        ddlGeneratedValue = pp.CaselessKeyword("GENERATED").setResultsName("hasGeneratedValue")
+        ddlAutoKeywords = [
+            "AUTO_INCREMENT",
+            "AUTOINCREMENT"
+        ]
+        ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True))).setResultsName("hasAutoValue")
+        ddlPrimaryKey = (pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")).setResultsName("isPrimaryKey")
+        ddlIgnoredKeywords = [
+            "CONSTRAINT",
+            "FOREIGN",
+            "KEY",
+            "FULLTEXT",
+            "INDEX",
+            "UNIQUE",
+            "CHECK",
+            "PERIOD",
+        ]
+        cls.ddlConstraint = (
+            pp.Or(map(
+                pp.CaselessKeyword,
+                sorted(ddlIgnoredKeywords + ["PRIMARY"], reverse=True)
+            ))
+            + cls.ddlExpression
+        ).setResultsName("isConstraint")
+
+        # Column parser
+        cls.ddlColumn = pp.Group(
+            ddlName.setResultsName("name")
+            + cls.ddlType.setResultsName("type")
+            + pp.Suppress(pp.Optional(ddlWidth))
+            + pp.Suppress(pp.Optional(ddlTimezone))
+            + pp.ZeroOrMore(
+                ddlUnsigned
+                | ddlNotNull
+                | pp.Suppress(pp.CaselessKeyword("NULL"))
+                | ddlAutoValue
+                | ddlDefaultValue
+                | ddlGeneratedValue
+                | ddlPrimaryKey
+                | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessKeyword, sorted(ddlIgnoredKeywords, reverse=True)))))
+                | pp.Suppress(cls.ddlExpression)
+            )
+        )
+
+        # CREATE TABLE parser
+        ddlCtBasic = (
+            pp.Suppress(pp.CaselessKeyword("CREATE"))
+            + pp.Suppress(pp.Optional(pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")))
+            + pp.Suppress(pp.CaselessKeyword("TABLE"))
+            + pp.Suppress(pp.Optional(pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")))
+            + ddlName.setResultsName("tableName")
+            + ddlLeft
+            + pp.Group(pp.delimitedList(pp.Suppress(cls.ddlConstraint) | cls.ddlColumn)).setResultsName("columns")
+            + ddlRight
+        )
+        def addCreateSql(text, loc, tokens):
+            create = tokens.create
+            create.value["createSql"] = text[create.locn_start:create.locn_end]
+        cls.ddlCtWithSql = pp.Located(ddlCtBasic).setResultsName("create").setParseAction(addCreateSql)
+
+        # Main DDL parser
+        cls.ddl = pp.OneOrMore(pp.Group(pp.Suppress(pp.SkipTo(ddlCtBasic, False)) + cls.ddlCtWithSql)).setResultsName("tables")
+        ddlComment = pp.oneOf(["--", "#"]) + pp.restOfLine
+        cls.ddl.ignore(ddlComment)
+        cls.ddl.parseWithTabs()
 
 
 class SelfTest:
@@ -311,7 +294,7 @@ class SelfTest:
     @classmethod
     def run(cls):
         print("Running self-test")
-        createDdlParser()
+        DdlParser.initialize()
         cls.testBoolean()
         cls.testInteger()
         cls.testSerial()
@@ -331,63 +314,63 @@ class SelfTest:
 
     @staticmethod
     def testBoolean():
-        for t in ddlBooleanTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlBooleanTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "boolean"
 
     @staticmethod
     def testInteger():
-        for t in ddlIntegerTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlIntegerTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "integral"
 
     @staticmethod
     def testSerial():
-        for t in ddlSerialTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlSerialTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "integral"
             assert result.hasSerialValue
 
     @staticmethod
     def testFloatingPoint():
-        for t in ddlFloatingPointTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlFloatingPointTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "floating_point"
 
     @staticmethod
     def testText():
-        for t in ddlTextTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlTextTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "text"
 
     @staticmethod
     def testBlob():
-        for t in ddlBlobTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlBlobTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "blob"
 
     @staticmethod
     def testDate():
-        for t in ddlDateTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlDateTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "date"
 
     @staticmethod
     def testDateTime():
-        for t in ddlDateTimeTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlDateTimeTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "timestamp"
 
     @staticmethod
     def testTime():
-        for t in ddlTimeTypes:
-            result = ddlType.parseString(t, parseAll=True)
+        for t in DdlParser.ddlTimeTypes:
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "time"
 
     @staticmethod
     def testUnknown():
         for t in ["cheesecake", "blueberry"]:
-            result = ddlType.parseString(t, parseAll=True)
+            result = DdlParser.ddlType.parseString(t, parseAll=True)
             assert result[0] == "UNKNOWN"
 
     @staticmethod
@@ -437,7 +420,7 @@ class SelfTest:
             }
         ]
         for td in testData:
-            result = ddlColumn.parseString(td["text"], parseAll=True)[0]
+            result = DdlParser.ddlColumn.parseString(td["text"], parseAll=True)[0]
             expected = td["expected"]
             assert result.name == expected["name"]
             assert result.type == expected["type"]
@@ -456,13 +439,13 @@ class SelfTest:
             "UNIQUE (id)",
             "UNIQUE (first_name,last_name)"
         ]:
-            result = ddlConstraint.parseString(text, parseAll=True)
+            result = DdlParser.ddlConstraint.parseString(text, parseAll=True)
             assert result.isConstraint
 
     @staticmethod
     def testMathExpression():
             text = "2 DIV 2"
-            result = ddlExpression.parseString(text, parseAll=True)
+            result = DdlParser.ddlExpression.parseString(text, parseAll=True)
             assert len(result) == 3
             assert result[0] == "2"
             assert result[1] == "DIV"
@@ -473,7 +456,7 @@ class SelfTest:
         for text in [
             "pos RATIONAL NOT NULL DEFAULT nextval('rational_seq')::integer",
         ]:
-            result = ddlColumn.parseString(text, parseAll=True)
+            result = DdlParser.ddlColumn.parseString(text, parseAll=True)
             column = result[0]
             assert column.name == "pos"
             assert column.type == "text"
@@ -489,7 +472,7 @@ class SelfTest:
     PRIMARY KEY (id)
     )
     """
-        result = ddlCtWithSql.parseString(text, parseAll=True)
+        result = DdlParser.ddlCtWithSql.parseString(text, parseAll=True)
 
     @staticmethod
     def testPrimaryKeyAutoIncrement():
@@ -498,7 +481,7 @@ class SelfTest:
             "CREATE TABLE tab (col INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT)", # mysql
             "CREATE TABLE tab (col INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT)", # sqlite
         ]:
-            result = ddlCtWithSql.parseString(text, parseAll=True)
+            result = DdlParser.ddlCtWithSql.parseString(text, parseAll=True)
             assert len(result) == 1
             table = result.create.value
             assert table.tableName == "tab"
@@ -749,7 +732,7 @@ def loadExtendedTypesFile(filename):
             var_values = [clean_val for value in row["extendedTypes"] if (clean_val := value.strip(" \"'"))]
             if var_values:
                 var_name = f"ddl{row['baseType']}Types"
-                globals()[var_name].extend(var_values)
+                getattr(DdlParser, var_name).extend(var_values)
 
 
 def parseCommandlineArgs():
@@ -801,9 +784,9 @@ def parseCommandlineArgs():
 
     return args
 
-def parseDdls(ddlParser, args):
+def parseDdls(args):
     try:
-        return [ddlParser.parseFile(path) for path in args.path_to_ddl]
+        return [DdlParser.ddl.parseFile(path) for path in args.path_to_ddl]
     except pp.ParseException as e:
         print("ERROR: failed to parse " + path)
         print(e.explain(1))
@@ -818,7 +801,7 @@ if __name__ == "__main__":
     else:
         if args.path_to_datatype_file:
             loadExtendedTypesFile(args.path_to_datatype_file)
-        ddlParser = createDdlParser()
-        parsedDdls = parseDdls(ddlParser, args)
+        DdlParser.initialize()
+        parsedDdls = parseDdls(args)
         ModelWriter.write(parsedDdls, args)
     sys.exit(ExitCode.SUCCESS)

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -723,18 +723,6 @@ class ModelWriter:
         return name
 
 
-# HELPERS
-def loadExtendedTypesFile(filename):
-    import csv
-    with open(filename, newline="") as csvfile:
-        reader = csv.DictReader(csvfile, fieldnames=["baseType"], restkey="extendedTypes", delimiter=",")
-        for row in reader:
-            var_values = [clean_val for value in row["extendedTypes"] if (clean_val := value.strip(" \"'"))]
-            if var_values:
-                var_name = f"ddl{row['baseType']}Types"
-                getattr(DdlParser, var_name).extend(var_values)
-
-
 def parseCommandlineArgs():
     argParser = argparse.ArgumentParser(prog="sqlpp23-ddl2cpp")
     required = argParser.add_argument_group("Required parameters for code generation")
@@ -783,6 +771,18 @@ def parseCommandlineArgs():
         sys.exit(ExitCode.BAD_ARGS)
 
     return args
+
+
+def loadExtendedTypesFile(filename):
+    import csv
+    with open(filename, newline="") as csvfile:
+        reader = csv.DictReader(csvfile, fieldnames=["baseType"], restkey="extendedTypes", delimiter=",")
+        for row in reader:
+            var_values = [clean_val for value in row["extendedTypes"] if (clean_val := value.strip(" \"'"))]
+            if var_values:
+                var_name = f"ddl{row['baseType']}Types"
+                getattr(DdlParser, var_name).extend(var_values)
+
 
 def parseDdls(args):
     try:

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -126,7 +126,7 @@ class DdlParser:
     ddl = None
 
     @classmethod
-    def initialize(cls):
+    def initialize(cls, customTypes=None):
         """Initialize the DDL parser"""
 
         # Basic parsers
@@ -165,37 +165,23 @@ class DdlParser:
         ddlFunctionCall << ddlName + ddlLeft + pp.Optional(ddlArguments) + ddlRight
 
         # Data type parsers
-        ddlBoolean = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlBooleanTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("boolean"))
-        ddlInteger = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlIntegerTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("integral"))
-        ddlSerial = (
-            pp.Or(map(pp.CaselessKeyword, sorted(cls.ddlSerialTypes, reverse=True)))
-            .setParseAction(pp.replaceWith("integral"))
-            .setResultsName("hasSerialValue")
-        )
-        ddlFloatingPoint = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlFloatingPointTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("floating_point"))
-        ddlText = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlTextTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("text"))
-        ddlBlob = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlBlobTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("blob"))
-        ddlDate = (
-            pp.Or(map(pp.CaselessKeyword, sorted(cls.ddlDateTypes, reverse=True)))
-            .setParseAction(pp.replaceWith("date"))
-            .setResultsName("warnTimezone")
-        )
-        ddlDateTime = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlDateTimeTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("timestamp"))
-        ddlTime = pp.Or(
-            map(pp.CaselessKeyword, sorted(cls.ddlTimeTypes, reverse=True))
-        ).setParseAction(pp.replaceWith("time"))
+        def get_type_parser(key, data_type):
+            type_names = getattr(cls, f"ddl{key}Types")
+            if customTypes and (key in customTypes):
+                type_names.extend(customTypes[key])
+            return pp.Or(
+                map(pp.CaselessKeyword, sorted(type_names, reverse=True))
+            ).setParseAction(pp.replaceWith(data_type))
+
+        ddlBoolean = get_type_parser("Boolean", "boolean")
+        ddlInteger = get_type_parser("Integer", "integral")
+        ddlSerial = get_type_parser("Serial", "integral").setResultsName("hasSerialValue")
+        ddlFloatingPoint = get_type_parser("FloatingPoint", "floating_point")
+        ddlText = get_type_parser("Text", "text")
+        ddlBlob = get_type_parser("Blob", "blob")
+        ddlDate = get_type_parser("Date", "date").setResultsName("warnTimezone")
+        ddlDateTime = get_type_parser("DateTime", "timestamp")
+        ddlTime = get_type_parser("Time", "time")
         ddlUnknown = pp.Word(pp.alphanums).setParseAction(pp.replaceWith("UNKNOWN"))
         cls.ddlType = (
             ddlBoolean
@@ -773,15 +759,18 @@ def parseCommandlineArgs():
     return args
 
 
-def loadExtendedTypesFile(filename):
+def get_extended_types(filename):
+    if not filename:
+        return None
     import csv
     with open(filename, newline="") as csvfile:
-        reader = csv.DictReader(csvfile, fieldnames=["baseType"], restkey="extendedTypes", delimiter=",")
+        reader = csv.DictReader(csvfile, fieldnames=["baseType"], restkey="customTypes", delimiter=",")
+        types = {}
         for row in reader:
-            var_values = [clean_val for value in row["extendedTypes"] if (clean_val := value.strip(" \"'"))]
+            var_values = [clean_val for value in row["customTypes"] if (clean_val := value.strip(" \"'").lower())]
             if var_values:
-                var_name = f"ddl{row['baseType']}Types"
-                getattr(DdlParser, var_name).extend(var_values)
+                types[row["baseType"]] = var_values
+        return types
 
 
 def parseDdls(args):
@@ -799,9 +788,8 @@ if __name__ == "__main__":
     if args.self_test:
         SelfTest.run()
     else:
-        if args.path_to_datatype_file:
-            loadExtendedTypesFile(args.path_to_datatype_file)
-        DdlParser.initialize()
+        customTypes = get_extended_types(args.path_to_datatype_file)
+        DdlParser.initialize(customTypes)
         parsedDdls = parseDdls(args)
         ModelWriter.write(parsedDdls, args)
     sys.exit(ExitCode.SUCCESS)

--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -803,10 +803,7 @@ def parseCommandlineArgs():
 
 def parseDdls(ddlParser, args):
     try:
-        ddls = []
-        for path in args.path_to_ddl:
-            ddls.append(ddlParser.parseFile(path))
-        return ddls
+        return [ddlParser.parseFile(path) for path in args.path_to_ddl]
     except pp.ParseException as e:
         print("ERROR: failed to parse " + path)
         print(e.explain(1))


### PR DESCRIPTION
This is the third PR that cleans up the ddl2cpp code. It provides the following changes:

- Wraps all the global DDL parser variables into a separate class (DdlParser). This pretty much gets rid of all the global variables that were polluting the global namespace.
- Cleans up the code that handles custom data types. The previous version seemed a bit hacky since it was modifying directly the global lists that contained the variable type names.
- Replaces a for-loop with a list comprehension.
- Clarifies the error message that is displayed when an unknown SQL data type is found in a DDL file. The previous error message stated:

> Error: unsupported datatypes.
> Possible solutions:
> A) Implement this datatype (examples: sqlpp23/data_types)
> B) Use the '{dataTypeFileArg}' command line argument to map the type to a known > type (example: README)
> C) Extend/upgrade sqlpp23-ddl2cpp (edit types map)
> D) Raise an issue on github

There we several problems with this:
- Solution A  (implementing the datatype in sqlpp23)  or C (adding the data type in sqlpp23-ddl2cpp) would not work alone, because one needs to modify both sqlpp23 and sqlpp23-ddl2cpp for the new type to be recognized. So I've merged A and C into a single solution.
- Solution B (mapping the unknown data type to a known one) would definitely work, so I made it the first proposed one.
- Solution D (Raise an issue on github) will work so I left it as the last proposed one.

Also the message did not make a difference between an SQL data type and an sqlpp23 data type and in fact these are different data types, an SQL data type is just a keyword, recognized by the database, e.g. `INT`, while the sqlpp23 data type is a C++ structure, e.g. `sqlpp23::integral`. So I tried to differentiate these two terms to make it clear that both should be implemented.

In the end the proposed error message looks like:

> Error: unsupported SQL data type(s).
> Possible solutions:
> A) Use the '--path-to-datatype-file' command line argument to map the SQL data type > to a known sqlpp23 data type (example: README)
> B) Implement this data type in sqlpp23 (examples: sqlpp23/data_types) and in sqlpp23-ddl2cpp
> C) Raise an issue on github
