### PR TITLE
ddl2cpp cleanup 4.1

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -30,9 +30,10 @@ import pyparsing as pp
 import sys
 import re
 import os
+from enum import IntEnum
 
 
-class ExitCode:
+class ExitCode(IntEnum):
     SUCCESS = 0
     BAD_ARGS = 1
     BAD_DATA_TYPE = 10


### PR DESCRIPTION
The 4th set of ddl2cpp cleanups turned out to be rather large, so I decided to split it into two parts, 4.1 and 4.2. This is 4.1, which contains just a few minor changes:

- `ModelWriter.createSplitHeaders()` and `ModelWriter.createModule()` had one of their parameters misspelled (`parsedDdl` instead of the correct `parsedDdls`). By pure luck the script worked correctly because there was a global variable, called `parsedDdls` with the correct value. Still this needs to be fixed. The commit also renames a couple of local vars to prevent future problems caused by local vars and parameters having too close names.
- Removed a superfluous call to setResultsName("warnTimezone"), because the result's name is not used anywhere. It seems that this result name was redundant from the very beginning when it was added in commit 5b3abca4b1785a0ee952d6f5f0ee081b9f614848
- Changed `ExitCode` to inherit from `enum.IntEnum`, to show that `ExitCode` is not a real class, but an enum.