### PR TITLE
module docs: Update the minimal supported GCC version.

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -12,7 +12,7 @@ import sqlpp23.postgresql;
 As of September 2025 (version 0.67), this is still evolving, but all tests build and pass with modules using either
 
 * clang++-20.1.2
-* g++-15.2
+* g++-15.2.0 or 15.3.0 (15.2.1 has a regression which prevents it from compiling sqlpp23 correctly)
 
 If you want to build tests with modules, call cmake with generator `ninja` and `-DBUILD_WITH_MODULES=ON`, e.g.
 


### PR DESCRIPTION
There is a regression in GCC which makes version 15.2.1 (the latest stable version), unable to compile sqlpp23 tests correctly when building with `-DBUILD_TESTING=ON -DBUILD_WITH_MODULES=ON`

Effectively it is hitting the [following GCC bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122625) which in some cases prevents compilation of modules that use `std::format` (and sqlpp23 does use it even in the core).

So I provided the following temporary update to the documentation explaining which GCC versions are supported. It's a bit verbose, but having it in the documentation will probably save users some time.