### PR TITLE
Various cleanups of the CMake scripts (part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ option(DEPENDENCY_CHECK "Check for dependencies of connector and the library" ON
 set(SQLPP23_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Sqlpp23 CACHE STRING "Path to sqlpp23 cmake files")
 
 ### Main (core) library
-add_component()
+add_core()
 
 ### Connector components
 if(BUILD_SQLITE3_CONNECTOR)


### PR DESCRIPTION
This is the second PR that cleans up the project CMake scripts and fixes a couple of issues.
Important changes made by this PR:

1. Fixes a bug in the project CMake scripts which caused all headers to be installed, even for connectors that were not enabled by a corresponding `-DBUILD_XXXXX_CONNECTOR=ON` command-line option. The bug was introduced in sqlpp11 with this commit https://github.com/rbock/sqlpp11/commit/d17bce96446416a98acd45f016b55790ac117925 and was later propagated to sqlpp23.  [This line](https://github.com/rbock/sqlpp11/commit/d17bce96446416a98acd45f016b55790ac117925#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR127) calles `install_component()` with an empty `DIRECTORY` and later [this line](https://github.com/rbock/sqlpp11/commit/d17bce96446416a98acd45f016b55790ac117925#diff-811c7f446f447b10b4c6c3d7456a446a7ee270466b8313b4d3f0cc0ff978249cR60) copies all the headers instead of just the component-specific headers.

2. Fixes a minor (cosmetic) issue which caused the display of multiple `-- Up-to-date: ...` messages during installation. The root cause of this issue was the same as the cause of bug 1. After all the headers were installed during the core library installation, attempts to install the component-specific headers caused CMake to display multiple `-- Up-to-date: ...` messages. 

3. Adds the C++23 requirement (`cxx_std_23`) to all the targets. Previously only the `sqlpp23::sqlpp23` target required C++23, so a project that linked only against a component target (e.g. `sqlpp23::postgresql`) would try to build without C++23 support and thus the build would fail. Granted, linking a project against a component target without the main target (`sqlpp23::sqlpp23`) can be considered a bug in the application that uses sqlpp23, but still I think it is better to explicitly require C++23 for connector components too.

4. There are a bunch of other minor changes (for example headers are copied using the recommended `FILE_SET` feature, instead of the old `install(DIRECTORY ...)` function.

Overall this PR sets up the infrastructure for the addition of the new module-specific targets. I will implement that in a separate PR, since I don't want to submit too big and complex PRs.