### PR TITLE
CMakeLists: Rename core target sqlpp23::sqlpp23 -> sqlpp23::core

### DIFF
--- a/cmake/Sqlpp23TargetHelper.cmake
+++ b/cmake/Sqlpp23TargetHelper.cmake
@@ -34,8 +34,8 @@ function(add_core)
         CONFIG_SCRIPT Sqlpp23Config.cmake
         HEADERS ${HEADERS}
         TARGET_NAME sqlpp23
-        TARGET_ALIAS sqlpp23::sqlpp23
-        TARGET_EXPORTED sqlpp23
+        TARGET_ALIAS sqlpp23::core
+        TARGET_EXPORTED core
     )
 endfunction()
 

--- a/cmake/configs/Sqlpp23Config.cmake
+++ b/cmake/configs/Sqlpp23Config.cmake
@@ -47,10 +47,13 @@ endforeach()
 # Add the target file
 include(${CMAKE_CURRENT_LIST_DIR}/Sqlpp23Targets.cmake)
 
-# Load any optional components 
+# Load any optional components
 foreach(comp IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_comps)
     include(${CMAKE_CURRENT_LIST_DIR}/Sqlpp23${comp}Config.cmake OPTIONAL)
 endforeach()
+
+# Add the target sqlpp23::sqlpp23 as an alias for sqlpp23::core
+add_library(sqlpp23::sqlpp23 ALIAS sqlpp23::core)
 
 # Import "ddl2cpp" script
 if(NOT TARGET sqlpp23::ddl2cpp)
@@ -65,6 +68,6 @@ if(NOT TARGET sqlpp23::ddl2cpp)
     unset(sqlpp23_ddl2cpp_location)
 endif()
 
-# Resture module path 
+# Resture module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_save})
 unset(CMAKE_MODULE_PATH_save)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,8 +21,9 @@ You can find examples for both methods in the examples folder.
 1. FetchContent (Recommended, no installation required)
 1. FindPackage (installation required, see below)
 
-Both methods will provide the `sqlpp23::sqlpp23` target as well as targets for
-each connector:
+Both methods will provide the core target `sqlpp23::core` as well as its alias
+`sqlpp23::sqlpp23` for backwards compatibility. Also the following connector-specific
+targets are provided:
 
 - sqlpp23::mysql
 - sqlpp23::mariadb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ if(BUILD_WITH_MODULES)
   target_link_libraries(sqlpp23_testing INTERFACE sqlpp23.core.module)
   target_compile_definitions(sqlpp23_testing INTERFACE BUILD_WITH_MODULES)
 else()
-  target_link_libraries(sqlpp23_testing INTERFACE sqlpp23)
+  target_link_libraries(sqlpp23_testing INTERFACE sqlpp23::core)
 endif()
 
 if (NOT MSVC)

--- a/tests/core/asserts/CMakeLists.txt
+++ b/tests/core/asserts/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test_for_setup name)
     set(target sqlpp23_core_asserts_setup_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 
@@ -34,7 +34,7 @@ function(test_assert name pattern)
     set(test sqlpp23_core_asserts_${name})
     set(target sqlpp23_core_asserts_${name})
     add_executable(${target} EXCLUDE_FROM_ALL ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     target_compile_definitions(${target} PRIVATE SQLPP_CHECK_STATIC_ASSERT)
     add_test(NAME ${test}
         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target ${target}

--- a/tests/core/constraints/aggregate_function/CMakeLists.txt
+++ b/tests/core/constraints/aggregate_function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_query_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/constraints/basic/CMakeLists.txt
+++ b/tests/core/constraints/basic/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_basic_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/constraints/clause/CMakeLists.txt
+++ b/tests/core/constraints/clause/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_clause_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/constraints/function/CMakeLists.txt
+++ b/tests/core/constraints/function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/constraints/operator/CMakeLists.txt
+++ b/tests/core/constraints/operator/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_operator_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/constraints/query/CMakeLists.txt
+++ b/tests/core/constraints/query/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_constraints_query_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/helpers/CMakeLists.txt
+++ b/tests/core/helpers/CMakeLists.txt
@@ -26,7 +26,7 @@
 function(test_compile name)
     set(target sqlpp23_helpers_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(circular_buffer)

--- a/tests/core/serialize/CMakeLists.txt
+++ b/tests/core/serialize/CMakeLists.txt
@@ -31,7 +31,7 @@ set(test_files
 
 create_test_sourcelist(test_sources test_serializer_main.cpp ${test_files})
 add_executable(sqlpp23_core_serialize ${test_sources})
-target_link_libraries(sqlpp23_core_serialize PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+target_link_libraries(sqlpp23_core_serialize PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 
 foreach(test_file IN LISTS test_files)
     get_filename_component(test ${test_file} NAME_WLE)

--- a/tests/core/serialize/aggregate_function/CMakeLists.txt
+++ b/tests/core/serialize/aggregate_function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_aggregate_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/basic/CMakeLists.txt
+++ b/tests/core/serialize/basic/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_basic_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/clause/CMakeLists.txt
+++ b/tests/core/serialize/clause/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_clause_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/data_types/CMakeLists.txt
+++ b/tests/core/serialize/data_types/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_data_type_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/function/CMakeLists.txt
+++ b/tests/core/serialize/function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/name/CMakeLists.txt
+++ b/tests/core/serialize/name/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_name_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/operator/CMakeLists.txt
+++ b/tests/core/serialize/operator/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_operator_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/serialize/query/CMakeLists.txt
+++ b/tests/core/serialize/query/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_serialize_query_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/types/CMakeLists.txt
+++ b/tests/core/types/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(dynamic)

--- a/tests/core/types/aggregate_function/CMakeLists.txt
+++ b/tests/core/types/aggregate_function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_aggregate_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(avg)

--- a/tests/core/types/basic/CMakeLists.txt
+++ b/tests/core/types/basic/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_basic_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(column)

--- a/tests/core/types/clause/CMakeLists.txt
+++ b/tests/core/types/clause/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_clause_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(cte)

--- a/tests/core/types/data_type/CMakeLists.txt
+++ b/tests/core/types/data_type/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_data_type_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(boolean)

--- a/tests/core/types/detail/CMakeLists.txt
+++ b/tests/core/types/detail/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_clause_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(get_last_if)

--- a/tests/core/types/function/CMakeLists.txt
+++ b/tests/core/types/function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(coalesce)

--- a/tests/core/types/name/CMakeLists.txt
+++ b/tests/core/types/name/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_name_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(char_sequence)

--- a/tests/core/types/operator/CMakeLists.txt
+++ b/tests/core/types/operator/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_operator_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(any)

--- a/tests/core/types/statement/CMakeLists.txt
+++ b/tests/core/types/statement/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_statement_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(no_of_result_columns)

--- a/tests/core/types/type_traits/CMakeLists.txt
+++ b/tests/core/types/type_traits/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(test_compile name)
     set(target sqlpp23_core_types_type_traits_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing)
 endfunction()
 
 test_compile(aggregates)

--- a/tests/core/usage/CMakeLists.txt
+++ b/tests/core/usage/CMakeLists.txt
@@ -40,7 +40,7 @@ set(test_files
 
 create_test_sourcelist(test_sources test_main.cpp ${test_files})
 add_executable(sqlpp23_core_tests ${test_sources})
-target_link_libraries(sqlpp23_core_tests PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
+target_link_libraries(sqlpp23_core_tests PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
 if (BUILD_WITH_MODULES)
   target_compile_definitions(sqlpp23_core_tests PRIVATE SQLPP23_USE_MODULES)
 endif()

--- a/tests/core/usage/aggregate_function/CMakeLists.txt
+++ b/tests/core/usage/aggregate_function/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_usage_aggregate_function_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/core/usage/statement/CMakeLists.txt
+++ b/tests/core/usage/statement/CMakeLists.txt
@@ -25,7 +25,7 @@
 function(create_test name)
     set(target sqlpp23_core_usage_statement_${name})
     add_executable(${target} ${name}.cpp)
-    target_link_libraries(${target} PRIVATE sqlpp23::sqlpp23 sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
+    target_link_libraries(${target} PRIVATE sqlpp23::core sqlpp23_testing sqlpp23_core_testing sqlpp23_core_testing)
     add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -88,7 +88,7 @@ if (${Python3_Interpreter_FOUND})
 
             add_executable(sqlpp.scripts.compiled.${sample_name} ${sample_name}.cpp
                 "${sqlpp.scripts.generated.sample.include}")
-            target_link_libraries(sqlpp.scripts.compiled.${sample_name} PRIVATE sqlpp23)
+            target_link_libraries(sqlpp.scripts.compiled.${sample_name} PRIVATE sqlpp23::core)
         endforeach()
 
         # Invalid .types names
@@ -128,6 +128,6 @@ if (${Python3_Interpreter_FOUND})
                 VERBATIM)
         endforeach()
         add_executable("${custom_type_exe}" "${custom_type_cpp}" ${custom_type_headers})
-        target_link_libraries("${custom_type_exe}" PRIVATE sqlpp23)
+        target_link_libraries("${custom_type_exe}" PRIVATE sqlpp23::core)
     endif()
 endif()


### PR DESCRIPTION
The sqlpp23 source code and documentation use in many places the term `core` to reference its core component, so I think it makes sense to rename the CMake core target from `sqlpp23::sqlpp23` to sqlpp23::core`, while providing `sqlpp23::sqlpp23` as it alias for compatibility purposes.

This PR implements this change.