### PR TITLE
Improve C++ type mapping in sqlpp23-ddl2cpp

### DIFF
--- a/scripts/sqlpp23-ddl2cpp
+++ b/scripts/sqlpp23-ddl2cpp
@@ -697,7 +697,10 @@ class ModelWriter:
                 + cls._escape_if_reserved(column.name) + ", " + column_member + ");"
                 , file=header)
             const_prefix = "const " if column.is_const else ""
-            type_str = column.cpp_type if column.cpp_type else "::sqlpp::" + column.data_type
+            if column.cpp_type:
+                type_str = column.cpp_type if "::" in column.cpp_type else "::sqlpp::" + column.cpp_type
+            else:
+                type_str = "::sqlpp::" + column.data_type
             if column.is_nullable:
                 print("      using data_type = " + const_prefix + "std::optional<" + type_str + ">;", file=header)
             else:

--- a/scripts/sqlpp23-ddl2cpp-unit-tests
+++ b/scripts/sqlpp23-ddl2cpp-unit-tests
@@ -632,6 +632,45 @@ class SelfTest(unittest.TestCase):
             tables = ddl2cpp.DdlExecutor.execute([parsed], make_args(postgresql_schema="public"), {})
             self.assertTrue(tables["t"].columns["a"].has_default)
 
+    def test_cpp_type_mapping(self):
+        import argparse
+        import io
+
+        def make_args(**kwargs):
+            defaults = dict(
+                path_to_header="test.h",
+                path_to_module=None,
+                namespace="db",
+                use_import_std=False,
+                use_import_sqlpp23=False,
+                generate_table_creation_helper=False,
+                naming_style="identity"
+            )
+            defaults.update(kwargs)
+            return argparse.Namespace(**defaults)
+
+        # Unqualified cpp_type -> prefixed with ::sqlpp::
+        with self.subTest("Unqualified cpp_type"):
+            col = ddl2cpp.DdlExecutor._ColumnDef(
+                name="col", data_type="integral", is_const=False, is_nullable=False,
+                has_default=False, is_array=False, comments=[], cpp_type="my_type"
+            )
+            table = ddl2cpp.DdlExecutor._TableDef(name="tab", columns={"col": col}, commands=[])
+            f = io.StringIO()
+            ddl2cpp.ModelWriter._write_table(table, f, make_args())
+            self.assertIn("using data_type = ::sqlpp::my_type;", f.getvalue())
+
+        # Qualified cpp_type -> as is
+        with self.subTest("Qualified cpp_type"):
+            col = ddl2cpp.DdlExecutor._ColumnDef(
+                name="col", data_type="integral", is_const=False, is_nullable=False,
+                has_default=False, is_array=False, comments=[], cpp_type="boost::uuid"
+            )
+            table = ddl2cpp.DdlExecutor._TableDef(name="tab", columns={"col": col}, commands=[])
+            f = io.StringIO()
+            ddl2cpp.ModelWriter._write_table(table, f, make_args())
+            self.assertIn("using data_type = boost::uuid;", f.getvalue())
+
 
 if __name__ == "__main__":
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)


### PR DESCRIPTION
The C++ type mapping in `scripts/sqlpp23-ddl2cpp` has been improved to distinguish between internal `sqlpp` types and custom external types.

- Unqualified type names like `integral` are now implicitly assumed to be part of `sqlpp` and are rendered as `::sqlpp::integral`.
- Qualified types like `boost::uuid` are treated as custom types and are rendered exactly as provided.

This change applies both to types mapped via `--path-to-cpp-types` and types specified via annotations in the DDL.

New unit tests have been added to `scripts/sqlpp23-ddl2cpp-unit-tests` to ensure correct rendering of both qualified and unqualified types.

---
*PR created automatically by Jules for task [4829381895434344141](https://jules.google.com/task/4829381895434344141) started by @rbock*