### PR TITLE
Fix CMake warnings about deprecated target SQLite::SQLite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,14 @@ add_component(NAME mock_db HEADER_DIR mock_db MODULE_INTERFACE sqlpp23.mock_db.c
 
 ### Connector components
 if(BUILD_SQLITE3_CONNECTOR)
-    add_component(NAME SQLite3 PACKAGE SQLite3 DEPENDENCIES SQLite::SQLite3 HEADER_DIR sqlite3 MODULE_INTERFACE sqlpp23.sqlite3.cppm)
+    # As documented here https://github.com/Kitware/CMake/blob/master/Modules/FindSQLite3.cmake
+    # starting with CMake 4.3.0, SQLite::SQLite3 is deprecated in favor of SQLite3::SQLite3
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.3.0")
+        set(SQLITE_DEPS "SQLite3::SQLite3")
+    else()
+        set(SQLITE_DEPS "SQLite::SQLite3")
+    endif()
+    add_component(NAME SQLite3 PACKAGE SQLite3 DEPENDENCIES ${SQLITE_DEPS} HEADER_DIR sqlite3 MODULE_INTERFACE sqlpp23.sqlite3.cppm)
 endif()
 if(BUILD_SQLCIPHER_CONNECTOR)
     add_component(NAME SQLCipher PACKAGE SQLCipher DEPENDENCIES SQLCipher::SQLCipher DEFINES SQLPP_USE_SQLCIPHER HEADER_DIR sqlite3 MODULE_INTERFACE sqlpp23.sqlite3.cppm)


### PR DESCRIPTION
Trying to build sqlpp23 with CMake 4.3.0 and the following command line
```
cmake -B build -G Ninja -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DDEPENDENCY_CHECK=ON -DBUILD_WITH_MODULES=ON
```
will show a whole bunch of repeating warnings saying the following
```
CMake Warning (dev) at cmake/Sqlpp23TargetHelper.cmake:161 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  cmake/Sqlpp23TargetHelper.cmake:111 (add_common)
  cmake/Sqlpp23TargetHelper.cmake:62 (add_regular_and_module)
  CMakeLists.txt:63 (add_component)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

The CMake script that searches for SQLite3 and creates the targets is not provided by SQLite3 but comes with CMake itself, so I checked the source code at https://github.com/Kitware/CMake/blob/master/Modules/FindSQLite3.cmake
and the comments in the script pretty much confirmed what the comments say: with CMake 4.3.0 or newer the target should be `SQLite3::SQLite3` instead of the old `SQLite::SQLite3`

So this fix checks the CMake version and uses the appropriate target.