### PR TITLE
Add missing exports from the core module

### DIFF
--- a/modules/sqlpp23.core.cppm
+++ b/modules/sqlpp23.core.cppm
@@ -67,6 +67,7 @@ using ::sqlpp::wrapped_static_assert; // TODO: Move
 // data types
 using ::sqlpp::boolean;
 using ::sqlpp::integral;
+using ::sqlpp::serial;
 using ::sqlpp::unsigned_integral;
 using ::sqlpp::floating_point;
 using ::sqlpp::text;

--- a/modules/sqlpp23.core.cppm
+++ b/modules/sqlpp23.core.cppm
@@ -400,6 +400,35 @@ using ::sqlpp::alias::exists_;
 using ::sqlpp::alias::max_;
 using ::sqlpp::alias::min_;
 using ::sqlpp::alias::sum_;
+
+using ::sqlpp::alias::a;
+using ::sqlpp::alias::b;
+using ::sqlpp::alias::c;
+using ::sqlpp::alias::d;
+using ::sqlpp::alias::e;
+using ::sqlpp::alias::f;
+using ::sqlpp::alias::g;
+using ::sqlpp::alias::h;
+using ::sqlpp::alias::i;
+using ::sqlpp::alias::j;
+using ::sqlpp::alias::k;
+using ::sqlpp::alias::l;
+using ::sqlpp::alias::m;
+using ::sqlpp::alias::n;
+using ::sqlpp::alias::o;
+using ::sqlpp::alias::p;
+using ::sqlpp::alias::q;
+using ::sqlpp::alias::r;
+using ::sqlpp::alias::s;
+using ::sqlpp::alias::t;
+using ::sqlpp::alias::u;
+using ::sqlpp::alias::v;
+using ::sqlpp::alias::w;
+using ::sqlpp::alias::x;
+using ::sqlpp::alias::y;
+using ::sqlpp::alias::z;
+using ::sqlpp::alias::left;
+using ::sqlpp::alias::right;
 }
 
 export namespace sqlpp::chrono {


### PR DESCRIPTION
This PR adds a few missing exports from the core module. More specifically the following types are added to the exports:
```
::sqlpp::serial
::sqlpp::alias::a - ::sqlpp::alias::z
::sqlpp::alias::left;
::sqlpp::alias::right;
```
I am not quite sure why the tests with enabled modules didn't catch those missing exports. Probably need to check that in more detail.