### PR TITLE
Fix variable expansion when installing component find scripts

### DIFF
--- a/cmake/sqlpp23_build_targets.cmake
+++ b/cmake/sqlpp23_build_targets.cmake
@@ -75,7 +75,7 @@ function(_add_build_regular_and_module)
         endif()
         if(NOT ARG_NO_INSTALL)
             # If the package needs a special find script, copy it to the destination scripts directory
-            set(find_script ${PROJECT_SOURCE_DIR}/cmake/modules/Find{ARG_PACKAGE}.cmake)
+            set(find_script ${PROJECT_SOURCE_DIR}/cmake/modules/Find${ARG_PACKAGE}.cmake)
             if(EXISTS ${find_script})
                 install(FILES ${find_script} DESTINATION ${SQLPP23_INSTALL_CMAKEDIR})
             endif()


### PR DESCRIPTION
`add_build_component`/`build_component` built the path to a component's Find<Package>.cmake helper as `Find{ARG_PACKAGE}.cmake` instead of `Find${ARG_PACKAGE}.cmake`. The missing `$` meant the variable was never expanded, so `EXISTS ${find_script}` was always false and the finder was never installed into ${SQLPP23_INSTALL_CMAKEDIR}.

As a result, the installed Sqlpp23<Component>Config.cmake (e.g. Sqlpp23MariaDBConfig.cmake) still runs `find_dependency(MariaDB)`, but the FindMariaDB.cmake module it relies on is absent from the package's cmake directory. Downstream consumers doing
`find_package(Sqlpp23 CONFIG REQUIRED COMPONENTS MariaDB)` then fail with:

  By not providing "FindMariaDB.cmake" in CMAKE_MODULE_PATH ...
  Could not find a package configuration file provided by "MariaDB"

This affects every component that ships a bundled find script (MariaDB, SQLCipher, ...). Expand the variable so the finder is installed alongside the component config.

@rbock Do you already have a timeline when you would release `0.70`?